### PR TITLE
Lagt til access-log for test-scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,12 @@
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.rakugakibox.spring.boot</groupId>
+            <artifactId>logback-access-spring-boot-starter</artifactId>
+            <version>2.7.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/src/test/resources/logback-access.xml
+++ b/src/test/resources/logback-access.xml
@@ -1,0 +1,8 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} Access-log %h %l %u "%r" %s %b "%i{Referer}" "%i{User-Agent}"</pattern>
+        </encoder>
+    </appender>
+    <appender-ref ref="CONSOLE" />
+</configuration>


### PR DESCRIPTION
Når man tester lokalt kan det være fint med access-log i konsollet, slik det er mulig å følge med å se att requester faktiskt kommer inn i applikasjoner.
Eks når applikasjonen mottar en request som ikke genererer noe logg

`2020-05-07 17:30:59,671 [INFO ] [main] n.n.f.e.s.ApplicationLocalLauncherKt - [, , ] - Started ApplicationLocalLauncherKt in 4.586 seconds (JVM running for 5.19)
2020-05-07 17:31:00,880 Access-log 0:0:0:0:0:0:0:1 - - "GET /test HTTP/1.1" 404 0 "-" "curl/7.64.1"`

Når vi deployer til preprod/prod i nais så finnes access-log i kibana fra traefik-ingress-lb

Edit:
Dette burde egentligen virke med kun access-log fra logback, men fikk det ikke til å virke. Og det var denne avhengigheten som internettet mente att det virker 
http://logback.qos.ch/access.html