### PR TITLE
Logging (tps hent person/barn)

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
@@ -3,8 +3,6 @@ package no.nav.familie.ef.søknad.service
 import no.nav.familie.ef.søknad.api.dto.Søkerinfo
 import no.nav.familie.ef.søknad.config.RegelverkConfig
 import no.nav.familie.ef.søknad.integration.TpsInnsynServiceClient
-import no.nav.familie.ef.søknad.integration.dto.PersoninfoDto
-import no.nav.familie.ef.søknad.integration.dto.RelasjonDto
 import no.nav.familie.ef.søknad.mapper.SøkerinfoMapper
 import org.apache.commons.logging.LogFactory
 import org.slf4j.LoggerFactory
@@ -24,28 +22,11 @@ internal class OppslagServiceServiceImpl(private val client: TpsInnsynServiceCli
     override fun hentSøkerinfo(): Søkerinfo {
         val personinfoDto = client.hentPersoninfo()
         val barn = client.hentBarn()
-
-        logSecure(personinfoDto, barn)
-
+        secureLogger.info("Personinfo: ${personinfoDto.ident}, Barn alder/samme adresse : ${
+            barn.map { Pair(it.alder, it.harSammeAdresse) }
+        },  ")
         val aktuelleBarn = barn.filter { erIAktuellAlder(it.fødselsdato) }
-
-        if (aktuelleBarn.size < barn.size) {
-            logSecure(personinfoDto, aktuelleBarn, "Aktuelle barn")
-        }
         return søkerinfoMapper.mapTilSøkerinfo(personinfoDto, aktuelleBarn)
-    }
-
-    private fun logSecure(personinfoDto: PersoninfoDto,
-                          barn: List<RelasjonDto>, tekst: String = "Barn alder/samme adresse") {
-        try {
-            val logTekst = "Personinfo: ${personinfoDto.ident}, $tekst : ${
-                barn.map { Pair(it.alder, it.harSammeAdresse) }
-            },  "
-            secureLogger.info(logTekst)
-        } catch (e: Exception) {
-            // svelg denne, kun logging
-        }
-
     }
 
     fun erIAktuellAlder(fødselsdato: LocalDate?): Boolean {

--- a/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
@@ -3,7 +3,11 @@ package no.nav.familie.ef.søknad.service
 import no.nav.familie.ef.søknad.api.dto.Søkerinfo
 import no.nav.familie.ef.søknad.config.RegelverkConfig
 import no.nav.familie.ef.søknad.integration.TpsInnsynServiceClient
+import no.nav.familie.ef.søknad.integration.dto.PersoninfoDto
+import no.nav.familie.ef.søknad.integration.dto.RelasjonDto
 import no.nav.familie.ef.søknad.mapper.SøkerinfoMapper
+import org.apache.commons.logging.LogFactory
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.time.Period
@@ -13,13 +17,35 @@ internal class OppslagServiceServiceImpl(private val client: TpsInnsynServiceCli
                                          private val regelverkConfig: RegelverkConfig,
                                          private val søkerinfoMapper: SøkerinfoMapper) : OppslagService {
 
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = LogFactory.getLog(this.javaClass)
+
+
     override fun hentSøkerinfo(): Søkerinfo {
         val personinfoDto = client.hentPersoninfo()
         val barn = client.hentBarn()
 
+        logSecure(personinfoDto, barn)
+
         val aktuelleBarn = barn.filter { erIAktuellAlder(it.fødselsdato) }
 
+        if (aktuelleBarn.size < barn.size) {
+            logSecure(personinfoDto, aktuelleBarn, "Aktuelle barn")
+        }
         return søkerinfoMapper.mapTilSøkerinfo(personinfoDto, aktuelleBarn)
+    }
+
+    private fun logSecure(personinfoDto: PersoninfoDto,
+                          barn: List<RelasjonDto>, tekst: String = "Barn alder/samme adresse") {
+        try {
+            val logTekst = "Personinfo: ${personinfoDto.ident}, $tekst : ${
+                barn.map { Pair(it.alder, it.harSammeAdresse) }
+            },  "
+            secureLogger.info(logTekst)
+        } catch (e: Exception) {
+            // svelg denne, kun logging
+        }
+
     }
 
     fun erIAktuellAlder(fødselsdato: LocalDate?): Boolean {

--- a/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ef.søknad.api.dto.Søkerinfo
 import no.nav.familie.ef.søknad.config.RegelverkConfig
 import no.nav.familie.ef.søknad.integration.TpsInnsynServiceClient
 import no.nav.familie.ef.søknad.mapper.SøkerinfoMapper
-import org.apache.commons.logging.LogFactory
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -16,8 +15,6 @@ internal class OppslagServiceServiceImpl(private val client: TpsInnsynServiceCli
                                          private val søkerinfoMapper: SøkerinfoMapper) : OppslagService {
 
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
-    private val logger = LogFactory.getLog(this.javaClass)
-
 
     override fun hentSøkerinfo(): Søkerinfo {
         val personinfoDto = client.hentPersoninfo()


### PR DESCRIPTION
En person som skulle søke om barnetilsyn hadde tre barn. To(tvillinger) var registrert som ikke boende hos ham (sjekket i gosys), en var registrert boende hos ham. Vi tror han fikk opp tvillingene, ikke barnet på 5 som var registrert hos ham. Klarer ikke gjenskape dette i test. 

Derfor: 

Legg på securelog i oppslagsservice for å kunne finne mulig feil i barn som vises for bruker. 
Logger ident + barn  (alder/harsammeadresse) vi får fra tps. 

ref:
https://jira.adeo.no/browse/FAGSYSTEM-131130
https://nav-it.slack.com/archives/G0104QDKZJQ/p1600856274001600