### PR TITLE
Bosituasjon gjenbrukes i framtidsplaner fix

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/mapper/kontrakt/BosituasjonMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/mapper/kontrakt/BosituasjonMapper.kt
@@ -23,6 +23,11 @@ object BosituasjonMapper : MapperMedVedlegg<Bosituasjon, KontraktBosituasjon>("B
     private fun mapSøkerDelerBoligMedAndre(bosituasjon: Bosituasjon) = bosituasjon.delerBoligMedAndreVoksne.tilSøknadsfelt()
 
     private fun mapSamboer(bosituasjon: Bosituasjon): Søknadsfelt<PersonMinimum>? {
+
+        if (bosituasjon.skalGifteSegEllerBliSamboer?.verdi == true) {
+            return null
+        }
+
         return bosituasjon.samboerDetaljer?.let {
             PersonMinimumMapper.map(it)
         }

--- a/src/main/kotlin/no/nav/familie/ef/søknad/mapper/kontrakt/SivilstandsplanerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/mapper/kontrakt/SivilstandsplanerMapper.kt
@@ -10,7 +10,12 @@ object SivilstandsplanerMapper : Mapper<Bosituasjon, Sivilstandsplaner>("Fremtid
     override fun mapDto(bosituasjon: Bosituasjon): Sivilstandsplaner {
         return Sivilstandsplaner(harPlaner = bosituasjon.skalGifteSegEllerBliSamboer?.tilSøknadsfelt(),
                                  fraDato = bosituasjon.datoSkalGifteSegEllerBliSamboer?.tilSøknadsfelt(),
-                                 vordendeSamboerEktefelle = bosituasjon.samboerDetaljer?.let(PersonMinimumMapper::map))
+                                 vordendeSamboerEktefelle = bosituasjon.skalGifteSegEllerBliSamboer?.let {
+                                     when (it.verdi) {
+                                         true -> bosituasjon.samboerDetaljer?.let(PersonMinimumMapper::map)
+                                         false -> null
+                                     }
+                                 })
     }
 
 }

--- a/src/test/kotlin/no/nav/familie/ef/søknad/mapper/BosituasjonMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/mapper/BosituasjonMapperTest.kt
@@ -79,7 +79,7 @@ internal class BosituasjonMapperTest {
         // When
         val samboerdetaljer = BosituasjonMapper.map(bosituasjonGifteplaner, dokumenter).verdi.samboerdetaljer
         // Then
-        assertThat(samboerdetaljer?.verdi?.navn?.verdi).isEqualTo("Giflteklar Navnesen")
+        assertThat(samboerdetaljer?.verdi?.navn?.verdi).isNull()
     }
 
     @Test
@@ -87,7 +87,7 @@ internal class BosituasjonMapperTest {
         // When
         val samboerdetaljer = BosituasjonMapper.map(bosituasjonGifteplaner, dokumenter).verdi.samboerdetaljer
         // Then
-        assertThat(samboerdetaljer?.verdi?.fødselsnummer?.verdi).isEqualTo(Fødselsnummer("26077624804"))
+        assertThat(samboerdetaljer?.verdi?.fødselsnummer?.verdi).isNull()
     }
 
     @Test
@@ -95,7 +95,7 @@ internal class BosituasjonMapperTest {
         // When
         val samboerdetaljer = BosituasjonMapper.map(bosituasjonGifteplaner, dokumenter).verdi.samboerdetaljer
         // Then
-        assertThat(samboerdetaljer?.verdi?.fødselsdato?.verdi).isEqualTo(LocalDate.of(1976, 7, 26))
+        assertThat(samboerdetaljer?.verdi?.fødselsdato?.verdi).isNull()
     }
 
     private fun getBosituasjon(fileName: String) = objectMapper.readValue(File("src/test/resources/$fileName"),


### PR DESCRIPTION
Problem: Gjenbruk av bosituasjon.samboerdetaljer i UI/modell 
Løsning:
1. Hvis en søker har planer om å gifte seg i framtiden - ikke map samboerdetaler under bosituasjon
2. Hvis en bruker har planer om å gifte seg i framtiden -> map bosituasjon.samboerdetaljer til Sivilstandsplaner

Bedre løsning (på sikt) ikke gjenbruke modell, men splitte gjeldende situasjon og framtidsplaner i UI (litt større oppgave) 

Testes funksjonelt i preprod nå. Vil ikke merges før denne jobben er ferdig. 

Skal løse feil/bug: 
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-2720
