### PR TITLE
Logg diff tps pdl to secure

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/mapper/FeltMapperUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/mapper/FeltMapperUtil.kt
@@ -45,19 +45,13 @@ fun DatoFelt.tilSøknadsDatoFeltEllerNull(): Søknadsfelt<LocalDate>? {
 }
 
 fun DatoFelt.tilSøknadsfelt(): Søknadsfelt<LocalDate> {
-    return if (this.verdi.isNotBlank()) {
-        Søknadsfelt(this.label, fraStrengTilLocalDate(this.verdi))
-    } else {
-        throw IllegalArgumentException("Kan ikke mappe datoFelt sin verdi når den er tom for ${this.label}")
-    }
+    require(this.verdi.isNotBlank()) { "Kan ikke mappe datoFelt sin verdi når den er tom for ${this.label}" }
+    return Søknadsfelt(this.label, fraStrengTilLocalDate(this.verdi))
 }
 
 fun DatoFelt.tilLocalDate(): LocalDate {
-    return if (this.verdi.isNotBlank()) {
-        fraStrengTilLocalDate(this.verdi)
-    } else {
-        throw IllegalArgumentException("Kan ikke mappe datoFelt sin verdi når den er tom for ${this.label}")
-    }
+    require(this.verdi.isNotBlank()) { "Kan ikke mappe datoFelt sin verdi når den er tom for ${this.label}" }
+    return fraStrengTilLocalDate(this.verdi)
 }
 
 fun DatoFelt.tilLocalDateEllerNull(): LocalDate? {

--- a/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceLoggHjelper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceLoggHjelper.kt
@@ -1,0 +1,97 @@
+package no.nav.familie.ef.søknad.service
+
+import no.nav.familie.ef.søknad.api.dto.Søkerinfo
+import no.nav.familie.ef.søknad.api.dto.tps.Barn
+import no.nav.familie.ef.søknad.api.dto.tps.Person
+import org.slf4j.LoggerFactory
+import kotlin.reflect.full.memberProperties
+
+@Deprecated("Denne skal fjernes så snart vi er helt over på PDL")
+object OppslagServiceLoggHjelper {
+
+
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
+    fun logDiff(søkerinfoV1: Søkerinfo, søkerinfoV2: Søkerinfo): String {
+        val builder = StringBuilder()
+        leggTilSøkerDiff(søkerinfoV1, søkerinfoV2, builder)
+        leggTilBarneDiff(søkerinfoV1, søkerinfoV2, builder)
+        if (builder.isNotBlank()) {
+            secureLogger.warn(builder.toString())
+        }
+        return builder.toString()
+    }
+
+    private fun leggTilBarneDiff(søkerinfoV1: Søkerinfo,
+                                 søkerinfoV2: Søkerinfo,
+                                 builder: StringBuilder) {
+        if (søkerinfoV1.barn.size != søkerinfoV2.barn.size) {
+            builder.append("Ikke samme antall barn fra tps og pdl: \n V1: ${søkerinfoV1.barn}, \n V2: ${søkerinfoV2.barn}")
+        } else {
+            val barn1Liste = søkerinfoV1.barn.sortedBy { it.fnr }
+            val barn2Liste = søkerinfoV2.barn.sortedBy { it.fnr }
+            val zip = barn1Liste.zip(barn2Liste)
+            zip.forEach {
+                for (prop in Barn::class.memberProperties) {
+                    val detErDiff = when (prop.name) {
+                        "navn" -> {
+                            listOfSeparatedNames(it.first.navn) != listOfSeparatedNames(it.second.navn)
+                        }
+                        else -> prop.get(it.first) != prop.get(it.second)
+                    }
+                    if (detErDiff) {
+                        builder.append("\n Barn: ${prop.name} = V1: ${prop.get(it.first)}, V2: ${prop.get(it.second)}")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun listOfSeparatedNames(name: String) =
+            name.split(" ").sorted()
+
+    private fun leggTilSøkerDiff(søkerinfoV1: Søkerinfo,
+                                 søkerinfoV2: Søkerinfo,
+                                 builder: StringBuilder) {
+        for (prop in Person::class.memberProperties) {
+            val property1 = prop.get(søkerinfoV1.søker)
+            val property2 = prop.get(søkerinfoV2.søker)
+            when (prop.name) {
+                "sivilstand" -> {
+                    logSivilstandsDiff(builder, søkerinfoV1.søker.sivilstand, søkerinfoV2.søker.sivilstand)
+                }
+                else -> {
+                    if (property1 != property2 && prop.name != "sivilstand") {
+                        builder.append("\n Person: ${prop.name} = V1: $property1, V2: $property2")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun logSivilstandsDiff(builder: StringBuilder, sivilstand1: String, sivilstand2: String) {
+
+        val erLikSivilstand = !when (sivilstand1) {
+            "SEPA", "SEPARERT" -> {
+                listOf("SEPA", "SEPARERT").contains(sivilstand2)
+            }
+            "UGIF", "UGIFT" -> {
+                listOf("UGIF", "UGIFT").contains(sivilstand2)
+            }
+            "SKIL", "SKILT" -> {
+                listOf("SKIL", "SKILT").contains(sivilstand2)
+            }
+            "ENKE", "ENKE_ELLER_ENKEMANN" -> {
+                listOf("ENKE", "ENKE_ELLER_ENKEMANN").contains(sivilstand2)
+            }
+            else -> sivilstand1 == sivilstand2
+        }
+
+        if (erLikSivilstand) {
+            builder.append(builder.append("\n Person: sivilstand = V1: $sivilstand1, V2: $sivilstand2"))
+        }
+
+
+    }
+
+}

--- a/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
@@ -1,8 +1,6 @@
 package no.nav.familie.ef.søknad.service
 
 import no.nav.familie.ef.søknad.api.dto.Søkerinfo
-import no.nav.familie.ef.søknad.api.dto.tps.Barn
-import no.nav.familie.ef.søknad.api.dto.tps.Person
 import no.nav.familie.ef.søknad.config.RegelverkConfig
 import no.nav.familie.ef.søknad.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.søknad.integration.PdlClient
@@ -16,7 +14,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.time.Period
-import kotlin.reflect.full.memberProperties
 
 @Service
 internal class OppslagServiceServiceImpl(private val client: TpsInnsynServiceClient,
@@ -37,7 +34,7 @@ internal class OppslagServiceServiceImpl(private val client: TpsInnsynServiceCli
 
         try {
             val hentSøkerinfoV2 = hentSøkerinfoV2()
-            logDiff(søkerinfoDto, hentSøkerinfoV2)
+            OppslagServiceLoggHjelper.logDiff(søkerinfoDto, hentSøkerinfoV2)
             if (featureToggleService.isEnabled("familie.ef.soknad.bruk-pdl")) {
                 return hentSøkerinfoV2
             }
@@ -50,87 +47,7 @@ internal class OppslagServiceServiceImpl(private val client: TpsInnsynServiceCli
         return søkerinfoDto
     }
 
-    fun logDiff(søkerinfoV1: Søkerinfo, søkerinfoV2: Søkerinfo): String {
-        val builder = StringBuilder()
-        leggTilSøkerDiff(søkerinfoV1, søkerinfoV2, builder)
-        leggTilBarneDiff(søkerinfoV1, søkerinfoV2, builder)
-        if (builder.isNotBlank()) {
-            secureLogger.warn(builder.toString())
-        }
-        return builder.toString()
-    }
 
-    private fun leggTilBarneDiff(søkerinfoV1: Søkerinfo,
-                                 søkerinfoV2: Søkerinfo,
-                                 builder: StringBuilder) {
-        if (søkerinfoV1.barn.size != søkerinfoV2.barn.size) {
-            builder.append("Ikke samme antall barn fra tps og pdl: \n V1: ${søkerinfoV1.barn}, \n V2: ${søkerinfoV2.barn}")
-        } else {
-            val barn1Liste = søkerinfoV1.barn.sortedBy { it.fnr }
-            val barn2Liste = søkerinfoV2.barn.sortedBy { it.fnr }
-            val zip = barn1Liste.zip(barn2Liste)
-            zip.forEach {
-                for (prop in Barn::class.memberProperties) {
-                    val detErDiff = when (prop.name) {
-                        "navn" -> {
-                            listOfSeparatedNames(it.first.navn) != listOfSeparatedNames(it.second.navn)
-                        }
-                        else -> prop.get(it.first) != prop.get(it.second)
-                    }
-                    if (detErDiff) {
-                        builder.append("\n Barn: ${prop.name} = V1: ${prop.get(it.first)}, V2: ${prop.get(it.second)}")
-                    }
-                }
-            }
-        }
-    }
-
-    private fun listOfSeparatedNames(name: String) =
-            name.split(" ").sorted()
-
-    private fun leggTilSøkerDiff(søkerinfoV1: Søkerinfo,
-                                 søkerinfoV2: Søkerinfo,
-                                 builder: StringBuilder) {
-        for (prop in Person::class.memberProperties) {
-            val property1 = prop.get(søkerinfoV1.søker)
-            val property2 = prop.get(søkerinfoV2.søker)
-            when (prop.name) {
-                "sivilstand" -> {
-                    logSivilstandsDiff(builder, søkerinfoV1.søker.sivilstand, søkerinfoV2.søker.sivilstand)
-                }
-                else -> {
-                    if (property1 != property2 && prop.name != "sivilstand") {
-                        builder.append("\n Person: ${prop.name} = V1: $property1, V2: $property2")
-                    }
-                }
-            }
-        }
-    }
-
-    private fun logSivilstandsDiff(builder: StringBuilder, sivilstand1: String, sivilstand2: String) {
-
-        val erLikSivilstand = !when (sivilstand1) {
-            "SEPA", "SEPARERT" -> {
-                listOf("SEPA", "SEPARERT").contains(sivilstand2)
-            }
-            "UGIF", "UGIFT" -> {
-                listOf("UGIF", "UGIFT").contains(sivilstand2)
-            }
-            "SKIL", "SKILT" -> {
-                listOf("SKIL", "SKILT").contains(sivilstand2)
-            }
-            "ENKE", "ENKE_ELLER_ENKEMANN" -> {
-                listOf("ENKE", "ENKE_ELLER_ENKEMANN").contains(sivilstand2)
-            }
-            else -> sivilstand1 == sivilstand2
-        }
-
-        if (erLikSivilstand) {
-            builder.append(builder.append("\n Person: sivilstand = V1: $sivilstand1, V2: $sivilstand2"))
-        }
-
-
-    }
 
 
     override fun hentSøkerinfoV2(): Søkerinfo {

--- a/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
@@ -50,37 +50,76 @@ internal class OppslagServiceServiceImpl(private val client: TpsInnsynServiceCli
         return søkerinfoDto
     }
 
-    fun logDiff(søkerinfoV1: Søkerinfo, søkerinfoV2: Søkerinfo) {
+    fun logDiff(søkerinfoV1: Søkerinfo, søkerinfoV2: Søkerinfo): String {
         val builder = StringBuilder()
-        for (prop in Person::class.memberProperties) {
-            val property1 = prop.get(søkerinfoV1.søker)
-            val property2 = prop.get(søkerinfoV2.søker)
-            if (property1 != property2) {
-                builder.append("Person: ${prop.name} = V1: $property1, V2: $property2")
-            }
+        leggTilSøkerDiff(søkerinfoV1, søkerinfoV2, builder)
+        leggTilBarneDiff(søkerinfoV1, søkerinfoV2, builder)
+        if (builder.isNotBlank()) {
+            secureLogger.warn(builder.toString())
         }
+        return builder.toString()
+    }
 
+    private fun leggTilBarneDiff(søkerinfoV1: Søkerinfo,
+                                 søkerinfoV2: Søkerinfo,
+                                 builder: StringBuilder) {
         if (søkerinfoV1.barn.size != søkerinfoV2.barn.size) {
-            builder.append("Ikke samme antall barn fra tps og pdl: ${System.lineSeparator()} ${søkerinfoV1.barn}, ${System.lineSeparator()} V2: ${søkerinfoV2.barn}")
+            builder.append("Ikke samme antall barn fra tps og pdl: \n V1: ${søkerinfoV1.barn}, \n V2: ${søkerinfoV2.barn}")
         } else {
             val barn1Liste = søkerinfoV1.barn.sortedBy { it.fnr }
             val barn2Liste = søkerinfoV2.barn.sortedBy { it.fnr }
             val zip = barn1Liste.zip(barn2Liste)
             zip.forEach {
                 for (prop in Barn::class.memberProperties) {
-                    val property1 = prop.get(it.first)
-                    val property2 = prop.get(it.second)
-                    if (property1 != property2) {
-                        builder.append("Barn: ${prop.name} = V1: $property1, V2: $property2")
+                    if (prop.name != "barn" && prop.get(it.first) != prop.get(it.second)) {
+                        builder.append("\n Barn: ${prop.name} = V1: ${prop.get(it.first)}, V2: ${prop.get(it.second)}")
                     }
                 }
             }
         }
-//        if (søkerinfoV1.barn != søkerinfoV2.barn) {
-//            builder.append("Ulike barn: V1: ${søkerinfoV1.barn}, V2: ${søkerinfoV2.barn}")
-//        }
+    }
 
-        return secureLogger.warn(builder.toString())
+    private fun leggTilSøkerDiff(søkerinfoV1: Søkerinfo,
+                                 søkerinfoV2: Søkerinfo,
+                                 builder: StringBuilder) {
+        for (prop in Person::class.memberProperties) {
+            val property1 = prop.get(søkerinfoV1.søker)
+            val property2 = prop.get(søkerinfoV2.søker)
+            when (prop.name) {
+                "sivilstand" -> {
+                    logSivilstandsDiff(builder, søkerinfoV1.søker.sivilstand, søkerinfoV2.søker.sivilstand)
+                }
+                else -> {
+                    if (property1 != property2 && prop.name != "sivilstand") {
+                        builder.append("\n Person: ${prop.name} = V1: $property1, V2: $property2")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun logSivilstandsDiff(builder: StringBuilder, sivilstand1: String, sivilstand2: String) {
+
+        val skalLogge = !when (sivilstand1) {
+            "SEPA", "SEPARERT" -> {
+                listOf("SEPA", "SEPARERT").contains(sivilstand2)
+            }
+            "UGIF", "UGIFT" -> {
+                listOf("UGIF", "UGIFT").contains(sivilstand2)
+            }
+            "SKIL", "SKILT" -> {
+                listOf("SKIL", "SKILT").contains(sivilstand2)
+            }
+            "ENKE", "ENKE_ELLER_ENKEMANN" -> {
+                listOf("ENKE", "ENKE_ELLER_ENKEMANN").contains(sivilstand2)
+            }
+            else -> sivilstand1 == sivilstand2
+        }
+
+        if (skalLogge) {
+            builder.append(builder.append("\n Person: sivilstand = V1: $sivilstand1, V2: $sivilstand2"))
+        }
+
 
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
@@ -109,7 +109,7 @@ internal class OppslagServiceServiceImpl(private val client: TpsInnsynServiceCli
 
     private fun logSivilstandsDiff(builder: StringBuilder, sivilstand1: String, sivilstand2: String) {
 
-        val skalLogge = !when (sivilstand1) {
+        val erLikSivilstand = !when (sivilstand1) {
             "SEPA", "SEPARERT" -> {
                 listOf("SEPA", "SEPARERT").contains(sivilstand2)
             }
@@ -125,7 +125,7 @@ internal class OppslagServiceServiceImpl(private val client: TpsInnsynServiceCli
             else -> sivilstand1 == sivilstand2
         }
 
-        if (skalLogge) {
+        if (erLikSivilstand) {
             builder.append(builder.append("\n Person: sivilstand = V1: $sivilstand1, V2: $sivilstand2"))
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
@@ -71,13 +71,22 @@ internal class OppslagServiceServiceImpl(private val client: TpsInnsynServiceCli
             val zip = barn1Liste.zip(barn2Liste)
             zip.forEach {
                 for (prop in Barn::class.memberProperties) {
-                    if (prop.name != "barn" && prop.get(it.first) != prop.get(it.second)) {
+                    val detErDiff = when (prop.name) {
+                        "navn" -> {
+                            listOfSeparatedNames(it.first.navn) != listOfSeparatedNames(it.second.navn)
+                        }
+                        else -> prop.get(it.first) != prop.get(it.second)
+                    }
+                    if (detErDiff) {
                         builder.append("\n Barn: ${prop.name} = V1: ${prop.get(it.first)}, V2: ${prop.get(it.second)}")
                     }
                 }
             }
         }
     }
+
+    private fun listOfSeparatedNames(name: String) =
+            name.split(" ").sorted()
 
     private fun leggTilSøkerDiff(søkerinfoV1: Søkerinfo,
                                  søkerinfoV2: Søkerinfo,

--- a/src/test/kotlin/no/nav/familie/ef/søknad/mock/DokumentController.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/mock/DokumentController.kt
@@ -43,9 +43,7 @@ class DokumentController(@Qualifier("dokumentlager") private val dokumenter: Mut
         val bytes = multipartFile.bytes
         val maxFileSizeInBytes = MAX_FILE_SIZE_MB * 1024 * 1024
 
-        if (bytes.size > maxFileSizeInBytes) {
-            throw IllegalArgumentException(HttpStatus.PAYLOAD_TOO_LARGE.toString())
-        }
+        require(bytes.size > maxFileSizeInBytes) { HttpStatus.PAYLOAD_TOO_LARGE.toString() }
 
         return try {
             val uuid = UUID.randomUUID().toString()

--- a/src/test/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceLoggHjelperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceLoggHjelperTest.kt
@@ -1,0 +1,78 @@
+package no.nav.familie.ef.søknad.service
+
+import no.nav.familie.ef.søknad.api.dto.Søkerinfo
+import no.nav.familie.ef.søknad.api.dto.tps.Adresse
+import no.nav.familie.ef.søknad.api.dto.tps.Barn
+import no.nav.familie.kontrakter.felles.objectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class OppslagServiceLoggHjelperTest {
+
+    @Test
+    fun `Skal ikke logge forskjeller når alt er likt`() {
+        val søkerinfo = objectMapper.readValue(søkerInfo, Søkerinfo::class.java)
+
+        val søkerPdl = søkerinfo.søker.copy(sivilstand = "UGIFT")
+        val søkerTps = søkerinfo.søker.copy(sivilstand = "UGIF")
+
+        val barnPdl = søkerinfo.barn.first().copy(navn = "Ola Olsen")
+        val barnTps = søkerinfo.barn.first().copy(navn = "Olsen Ola")
+
+        val søkerinfoPdl = søkerinfo.copy(søker = søkerPdl, barn = listOf(barnPdl))
+        val søkerinfoTps = søkerinfo.copy(søker = søkerTps, barn = listOf(barnTps))
+        assertThat(OppslagServiceLoggHjelper.logDiff(søkerinfoTps, søkerinfoPdl)).isBlank
+    }
+
+    @Test
+    fun `Skal logge forskjeller på Person og barn data`() {
+        val søkerinfo = objectMapper.readValue(søkerInfo, Søkerinfo::class.java)
+        val endretSøker = søkerinfo.søker.copy(fnr = "54325432",
+                                               adresse = Adresse("nyAdresse", "7654", "AnnetSted"),
+                                               statsborgerskap = "ANNET",
+                                               sivilstand = "UKJENT",
+                                               egenansatt = true,
+                                               forkortetNavn = "KORT")
+        val barn = Barn("456776544567",
+                        "Ole Annetnavn",
+                        2,
+                        LocalDate.now(),
+                        false)
+        val søkerinfo2 = søkerinfo.copy(søker = endretSøker, barn = listOf(barn))
+        assertThat(OppslagServiceLoggHjelper.logDiff(søkerinfo, søkerinfo2)).isNotBlank
+    }
+
+    @Test
+    fun `Skal logge forskjeller - manglende barn`() {
+        val søkerinfo = objectMapper.readValue(søkerInfo, Søkerinfo::class.java)
+        val søkerinfo2 = søkerinfo.copy(barn = listOf())
+        assertThat(OppslagServiceLoggHjelper.logDiff(søkerinfo, søkerinfo2)).isNotBlank
+    }
+}
+
+
+val søkerInfo = """{
+  "søker": {
+    "fnr": "08018820243",
+    "forkortetNavn": "TUNGSINDIG GASELLE",
+    "adresse": {
+      "adresse": "SELSBAKKEN 93",
+      "postnummer": "0561",
+      "poststed": "OSLO"
+    },
+    "egenansatt": false,
+    "sivilstand": "UGIF",
+    "statsborgerskap": "NORGE"
+  },
+  "barn": [
+    {
+      "fnr": "28021961053",
+      "navn": "DORULL RASK",
+      "alder": 1,
+      "fødselsdato": "2019-02-28",
+      "harSammeAdresse": true
+    }
+  ],
+  "hash": "664551484"
+} """

--- a/src/test/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImplTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImplTest.kt
@@ -50,10 +50,15 @@ internal class OppslagServiceServiceImplTest {
     @Test
     fun `Skal ikke logge forskjeller når alt er likt`() {
         val søkerinfo = objectMapper.readValue(søkerInfo, Søkerinfo::class.java)
+
         val søkerPdl = søkerinfo.søker.copy(sivilstand = "UGIFT")
         val søkerTps = søkerinfo.søker.copy(sivilstand = "UGIF")
-        val søkerinfoPdl = søkerinfo.copy(søker = søkerPdl)
-        val søkerinfoTps = søkerinfo.copy(søker = søkerTps)
+
+        val barnPdl = søkerinfo.barn.first().copy(navn = "Ola Olsen")
+        val barnTps = søkerinfo.barn.first().copy(navn = "Olsen Ola")
+
+        val søkerinfoPdl = søkerinfo.copy(søker = søkerPdl, barn = listOf(barnPdl))
+        val søkerinfoTps = søkerinfo.copy(søker = søkerTps, barn = listOf(barnTps))
         assertThat(oppslagServiceService.logDiff(søkerinfoTps, søkerinfoPdl)).isBlank
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImplTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImplTest.kt
@@ -43,6 +43,40 @@ internal class OppslagServiceServiceImplTest {
         mockHentPersonPdlClient()
     }
 
+
+    @Test
+    fun `Skal ikke logge forskjeller når alt er likt`() {
+        val søkerinfo = objectMapper.readValue(søkerInfo, Søkerinfo::class.java)
+        val søkerinfo2 = søkerinfo.copy()
+        assertThat(oppslagServiceService.hentDiff(søkerinfo, søkerinfo2)).isBlank()
+    }
+
+    @Test
+    fun `Skal logge forskjeller på Person og barn data`() {
+        val søkerinfo = objectMapper.readValue(søkerInfo, Søkerinfo::class.java)
+        val endretSøker = søkerinfo.søker.copy(fnr = "54325432",
+                                               adresse = Adresse("nyAdresse", "7654", "AnnetSted"),
+                                               statsborgerskap = "ANNET",
+                                               sivilstand = "UKJENT",
+                                               egenansatt = true,
+                                               forkortetNavn = "KORT")
+        val barn = Barn("456776544567",
+                        "Ole Annetnavn",
+                        2,
+                        LocalDate.now(),
+                        false)
+        val søkerinfo2 = søkerinfo.copy(søker = endretSøker, barn = listOf(barn))
+        assertThat(oppslagServiceService.hentDiff(søkerinfo, søkerinfo2)).isNotBlank
+    }
+
+    @Test
+    fun `Skal logge forskjeller - manglende barn`() {
+        val søkerinfo = objectMapper.readValue(søkerInfo, Søkerinfo::class.java)
+        val søkerinfo2 = søkerinfo.copy(barn = listOf())
+        assertThat(oppslagServiceService.hentDiff(søkerinfo, søkerinfo2)).isNotBlank()
+    }
+
+
     @Test
     fun `Lik søkerInfo skal ha lik hash`() {
         val søkerinfo = oppslagServiceService.hentSøkerinfo()


### PR DESCRIPTION
Logger diff mellom tps og pdl. Logger ikke diff på de opplagte forskjellene på sivilstandstatus, men her kunne vi kanskje lagt inn flere. 

Logger ikke diff på navn barn selv om disse kommer i forskjellig rekkefølge fra tps. (split/sort) 

Testene som er lagt til er ikke veldig nøye på assertene, men de fungerer mest for å se at ting fungerer noenlunde. Hadde egentlig ikke tenkt å legge på tester, men det var lettere å endre på kode når jeg hadde med disse. 

Spørsmål -> flytte ut av service? 

to små endringer (throw Illegal => require) hører egentlig ikke med til dette. 