### PR TITLE
Tps: SEPR, Pdl: SEPARERT

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceLoggHjelper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceLoggHjelper.kt
@@ -92,8 +92,8 @@ object OppslagServiceLoggHjelper {
     private fun erUlikSivilstand(tpsSivilstand: String, pdlSivilstand: String): Boolean {
         val tpsTilPdlSivilstand = when (tpsSivilstand) {
             "REPA" -> "PARTNER"
-            "SEPA" -> "SEPARERT"
-            "SEPR" -> "SEPARERT_PARTNER"
+            "SEPA" -> "SEPARERT_PARTNER"
+            "SEPR" -> "SEPARERT"
             "GJPA" -> "GJENLEVENDE_PARTNER"
             "UGIF" -> "UGIFT"
             "SAMB" -> "UGIFT"


### PR DESCRIPTION
Mini-pr: Mange unødvendige linjer i securelog av typen "Person: sivilstand = Tps: SEPR, Pdl: SEPARERT". Bytter om på mapping av SEPR og SEPA? 