### PR TITLE
Send svarid søknad

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <fasterxml.version>2.12.1</fasterxml.version>
         <com.amazonaws.version>1.11.934</com.amazonaws.version>
         <felles.version>1.20210107110757_9601bec</felles.version>
-        <kontrakter.version>2.0_20210105115213_05f0728</kontrakter.version>
+        <kontrakter.version>2.0_20210111142415_4adc8c0</kontrakter.version>
         <start-class>no.nav.familie.ef.søknad.ApplicationKt</start-class>
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>

--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,9 @@
         <springfox.version>3.0.0</springfox.version>
         <mockk.version>1.10.4</mockk.version>
         <token-validation-spring.version>1.3.2</token-validation-spring.version>
-        <fasterxml.version>2.12.0</fasterxml.version>
-        <com.amazonaws.version>1.11.933</com.amazonaws.version>
-        <felles.version>1.20210106133220_c683c96</felles.version>
+        <fasterxml.version>2.12.1</fasterxml.version>
+        <com.amazonaws.version>1.11.934</com.amazonaws.version>
+        <felles.version>1.20210107110757_9601bec</felles.version>
         <kontrakter.version>2.0_20210105115213_05f0728</kontrakter.version>
         <start-class>no.nav.familie.ef.søknad.ApplicationKt</start-class>
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->

--- a/src/main/kotlin/no/nav/familie/ef/søknad/api/dto/søknadsdialog/FeltTyper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/api/dto/søknadsdialog/FeltTyper.kt
@@ -4,7 +4,8 @@ data class BooleanFelt(val label: String,
                        val verdi: Boolean)
 
 data class TekstFelt(val label: String,
-                     val verdi: String)
+                     val verdi: String,
+                     val svarid: String? = null)
 
 data class DatoFelt(val label: String,
                     val verdi: String)
@@ -14,7 +15,8 @@ data class DokumentFelt(val dokumentId: String,
 
 data class ListFelt<T>(val label: String,
                        val verdi: List<T>,
-                       val alternativer: List<String>? = null)
+                       val alternativer: List<String>? = null,
+                       val svarIder: List<T>? = null)
 
 data class HeltallFelt(val label: String,
                        val verdi: Int)

--- a/src/main/kotlin/no/nav/familie/ef/søknad/api/dto/søknadsdialog/FeltTyper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/api/dto/søknadsdialog/FeltTyper.kt
@@ -16,7 +16,7 @@ data class DokumentFelt(val dokumentId: String,
 data class ListFelt<T>(val label: String,
                        val verdi: List<T>,
                        val alternativer: List<String>? = null,
-                       val svarIder: List<T>? = null)
+                       val svarid: List<T>? = null)
 
 data class HeltallFelt(val label: String,
                        val verdi: Int)

--- a/src/main/kotlin/no/nav/familie/ef/søknad/mapper/FeltMapperUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/mapper/FeltMapperUtil.kt
@@ -23,7 +23,7 @@ fun PeriodeFelt.tilSøknadsfelt(): Søknadsfelt<MånedÅrPeriode> =
                                    this.til.tilLocalDate().month,
                                    this.til.tilLocalDate().year))
 
-fun <T> ListFelt<T>.tilSøknadsfelt(): Søknadsfelt<List<T>> = Søknadsfelt(this.label, this.verdi, this.alternativer, this.svarIder)
+fun <T> ListFelt<T>.tilSøknadsfelt(): Søknadsfelt<List<T>> = Søknadsfelt(this.label, this.verdi, this.alternativer, this.svarid)
 
 fun List<Dokumentasjonsbehov>.tilKontrakt() : List<DokumentasjonsbehovKontrakt> =
         this.map {

--- a/src/main/kotlin/no/nav/familie/ef/søknad/mapper/FeltMapperUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/mapper/FeltMapperUtil.kt
@@ -13,8 +13,8 @@ fun BooleanFelt.tilSøknadsfelt(): Søknadsfelt<Boolean> = Søknadsfelt(this.lab
 
 fun HeltallFelt.tilSøknadsfelt(): Søknadsfelt<Int> = Søknadsfelt(this.label, this.verdi)
 
-fun TekstFelt.tilSøknadsfelt(): Søknadsfelt<String> = Søknadsfelt(this.label, this.verdi)
-fun <T> TekstFelt.tilSøknadsfelt(t: (String) -> T): Søknadsfelt<T> = Søknadsfelt(this.label, t.invoke(this.verdi))
+fun TekstFelt.tilSøknadsfelt(): Søknadsfelt<String> = Søknadsfelt(label = this.label, verdi = this.verdi, svarId = this.svarid)
+fun <T> TekstFelt.tilSøknadsfelt(t: (String) -> T): Søknadsfelt<T> = Søknadsfelt(label = this.label, verdi = t.invoke(this.verdi))
 
 fun PeriodeFelt.tilSøknadsfelt(): Søknadsfelt<MånedÅrPeriode> =
         Søknadsfelt(this.label ?: error("Savner label"),
@@ -23,7 +23,7 @@ fun PeriodeFelt.tilSøknadsfelt(): Søknadsfelt<MånedÅrPeriode> =
                                    this.til.tilLocalDate().month,
                                    this.til.tilLocalDate().year))
 
-fun <T> ListFelt<T>.tilSøknadsfelt(): Søknadsfelt<List<T>> = Søknadsfelt(this.label, this.verdi, this.alternativer)
+fun <T> ListFelt<T>.tilSøknadsfelt(): Søknadsfelt<List<T>> = Søknadsfelt(this.label, this.verdi, this.alternativer, this.svarIder)
 
 fun List<Dokumentasjonsbehov>.tilKontrakt() : List<DokumentasjonsbehovKontrakt> =
         this.map {

--- a/src/test/kotlin/no/nav/familie/ef/søknad/mapper/FeltMapperUtilKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/mapper/FeltMapperUtilKtTest.kt
@@ -30,9 +30,11 @@ internal class FeltMapperUtilKtTest {
 
     @Test
     internal fun `TekstFelt med mapper`() {
-        val felt = TekstFelt("label", "08031499039", "svarid").tilSøknadsfelt(::Fødselsnummer)
-        assertEquals(Søknadsfelt("label", Fødselsnummer("08031499039"), svarId = "svarid"), felt)
+        val felt = TekstFelt("label", "08031499039").tilSøknadsfelt(::Fødselsnummer)
+        assertEquals(Søknadsfelt("label", Fødselsnummer("08031499039")), felt)
     }
+
+
 
     @Test
     internal fun `BooleanFelt`() {

--- a/src/test/kotlin/no/nav/familie/ef/søknad/mapper/FeltMapperUtilKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/mapper/FeltMapperUtilKtTest.kt
@@ -50,7 +50,7 @@ internal class FeltMapperUtilKtTest {
 
     @Test
     internal fun `ListFelt`() {
-        val felt = ListFelt(label = "label", verdi = listOf("a"), svarIder = listOf("1")).tilSøknadsfelt()
+        val felt = ListFelt(label = "label", verdi = listOf("a"), svarid = listOf("1")).tilSøknadsfelt()
         assertEquals(Søknadsfelt(label = "label", verdi = listOf("a"), svarId = listOf("1")), felt)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/søknad/mapper/FeltMapperUtilKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/mapper/FeltMapperUtilKtTest.kt
@@ -23,15 +23,15 @@ internal class FeltMapperUtilKtTest {
 
     @Test
     internal fun `TekstFelt`() {
-        val felt = TekstFelt("label", "verdi").tilSøknadsfelt()
-        assertEquals(Søknadsfelt("label", "verdi"), felt)
-        assertNotEquals(Søknadsfelt("label", "verdi2"), felt)
+        val felt = TekstFelt("label", "verdi", "svarid").tilSøknadsfelt()
+        assertEquals(Søknadsfelt(label = "label", verdi = "verdi", svarId = "svarid"), felt)
+        assertNotEquals(Søknadsfelt(label = "label", verdi = "verdi2", svarId = "svarid"), felt)
     }
 
     @Test
     internal fun `TekstFelt med mapper`() {
-        val felt = TekstFelt("label", "08031499039").tilSøknadsfelt(::Fødselsnummer)
-        assertEquals(Søknadsfelt("label", Fødselsnummer("08031499039")), felt)
+        val felt = TekstFelt("label", "08031499039", "svarid").tilSøknadsfelt(::Fødselsnummer)
+        assertEquals(Søknadsfelt("label", Fødselsnummer("08031499039"), svarId = "svarid"), felt)
     }
 
     @Test
@@ -48,8 +48,8 @@ internal class FeltMapperUtilKtTest {
 
     @Test
     internal fun `ListFelt`() {
-        val felt = ListFelt("label", listOf("a")).tilSøknadsfelt()
-        assertEquals(Søknadsfelt("label", listOf("a")), felt)
+        val felt = ListFelt(label = "label", verdi = listOf("a"), svarIder = listOf("1")).tilSøknadsfelt()
+        assertEquals(Søknadsfelt(label = "label", verdi = listOf("a"), svarId = listOf("1")), felt)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/søknad/mapper/SkjemaMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/mapper/SkjemaMapperTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertFailsWith
 internal class SkjemaMapperTest {
 
 
-    val hvorØnskerSøkerArbeid: TekstFelt = TekstFelt("label", "Hvorsomhelst")
+    val hvorØnskerSøkerArbeid: TekstFelt = TekstFelt("label", "Hvorsomhelst", "hvasomhelst")
     val kanBegynneInnenEnUke: BooleanFelt = BooleanFelt("label", false)
     val kanSkaffeBarnepassInnenEnUke: BooleanFelt = BooleanFelt("label", false)
     val registrertSomArbeidssøkerNav: BooleanFelt = BooleanFelt("label", false)


### PR DESCRIPTION
```familie-ef-soknad```  (frontend) sender allerede med svarid til ```ef-soknad-api```. Denne PR gjør at vi legger på svarid i søknadsobsjektet vi sender videre til ```ef-mottak```,  for tekstfelt.  Dette er for å kunne sammenligne på svarid istedenfor "svar verdi" i ```ef-sak-frontend```.

Vi ønsker f.eks. å kunne gjøre ca. dette:
```
switch (bosituasjon.delerDuBolig){
  case EDelerbolig.borAlene:
    return ABC
  case EDelerbolig.borMedPartner:
    return BAR
  ....
}
```

der bosituasjon.delerDuBolig lages basert på svarid 
