### PR TITLE
Bytt ut tps med pdl.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/api/OppslagController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/api/OppslagController.kt
@@ -26,11 +26,6 @@ class OppslagController(private val oppslagService: OppslagService,
         return oppslagService.hentSøkerinfo()
     }
 
-    @GetMapping("/sokerinfoV2")
-    fun søkerinfo_V2(): Søkerinfo {
-        return oppslagService.hentSøkerinfoV2()
-    }
-
     @GetMapping("/poststed/{postnummer}")
     fun postnummer(@PathVariable postnummer: String): ResponseEntity<String> {
         require(gyldigPostnummer(postnummer))

--- a/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagService.kt
@@ -6,7 +6,4 @@ interface OppslagService {
 
     fun hentSøkerinfo(): Søkerinfo
 
-    fun hentSøkerinfoV2(): Søkerinfo
-
-
 }


### PR DESCRIPTION
Når vi merger denne vil vi ta i bruk pdl i prod. 

Vi fortsetter å logge diff mellom pdl og tps. Usikker på hvor stor verdi dette har?

Fjernet bruk av toggle: "familie.ef.soknad.bruk-pdl", så denne kan slettes fra unleash. 
=> Dersom vi ønsker å gå tilbake til tps må vi gjøre en redeploy. 