### PR TITLE
- Legg til vordendeSamboerEktefelle i Bosituasjon datamodell fra søkn…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/api/dto/søknadsdialog/Bosituasjon.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/api/dto/søknadsdialog/Bosituasjon.kt
@@ -6,18 +6,11 @@ data class Bosituasjon(
         val samboerDetaljer: SamboerDetaljer?,
         val datoSkalGifteSegEllerBliSamboer: DatoFelt? = null,
         val skalGifteSegEllerBliSamboer: BooleanFelt?,
-        val datoFlyttetFraHverandre: DatoFelt?
-)
-
-//delerBoligMedAndreVoksne: ISpørsmålBooleanFeltlFelt;
-//datoFlyttetSammenMedSamboer?: IDatoFelt;
-//samboerDetaljer?: IPersonDetaljer;
-//datoSkalGifteSegEllerBliSamboer?: IDatoFelt;
-//skalGifteSegEllerBliSamboer?: ISpørsmålBooleanFelt;
-//datoFlyttetFraHverandre?: IDatoFelt;
+        val datoFlyttetFraHverandre: DatoFelt?,
+        val vordendeSamboerEktefelle: SamboerDetaljer?,
+        )
 
 data class SamboerDetaljer(
-       // val fødselsnummer: String?,
         val fødselsdato: DatoFelt?,
         val navn: TekstFelt,
         val ident: TekstFelt? = null

--- a/src/main/kotlin/no/nav/familie/ef/søknad/mapper/kontrakt/BosituasjonMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/mapper/kontrakt/BosituasjonMapper.kt
@@ -25,10 +25,6 @@ object BosituasjonMapper : MapperMedVedlegg<Bosituasjon, KontraktBosituasjon>(Bo
 
     private fun mapSamboer(bosituasjon: Bosituasjon): Søknadsfelt<PersonMinimum>? {
 
-        if (bosituasjon.skalGifteSegEllerBliSamboer?.verdi == true) {
-            return null
-        }
-
         return bosituasjon.samboerDetaljer?.let {
             PersonMinimumMapper.map(it)
         }

--- a/src/main/kotlin/no/nav/familie/ef/søknad/mapper/kontrakt/SivilstandsplanerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/mapper/kontrakt/SivilstandsplanerMapper.kt
@@ -11,12 +11,7 @@ object SivilstandsplanerMapper : Mapper<Bosituasjon, Sivilstandsplaner>(Fremtids
     override fun mapDto(bosituasjon: Bosituasjon): Sivilstandsplaner {
         return Sivilstandsplaner(harPlaner = bosituasjon.skalGifteSegEllerBliSamboer?.tilSøknadsfelt(),
                                  fraDato = bosituasjon.datoSkalGifteSegEllerBliSamboer?.tilSøknadsfelt(),
-                                 vordendeSamboerEktefelle = bosituasjon.skalGifteSegEllerBliSamboer?.let {
-                                     when (it.verdi) {
-                                         true -> bosituasjon.samboerDetaljer?.let(PersonMinimumMapper::map)
-                                         false -> null
-                                     }
-                                 })
+                                 vordendeSamboerEktefelle =  bosituasjon.vordendeSamboerEktefelle?.let(PersonMinimumMapper::map))
     }
 
 }

--- a/src/test/kotlin/no/nav/familie/ef/søknad/mapper/BosituasjonMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/mapper/BosituasjonMapperTest.kt
@@ -79,7 +79,7 @@ internal class BosituasjonMapperTest {
         // When
         val samboerdetaljer = BosituasjonMapper.map(bosituasjonGifteplaner, dokumenter).verdi.samboerdetaljer
         // Then
-        assertThat(samboerdetaljer?.verdi?.navn?.verdi).isNull()
+        assertThat(samboerdetaljer?.verdi?.navn?.verdi).isEqualTo("Giflteklar Navnesen")
     }
 
     @Test
@@ -87,7 +87,7 @@ internal class BosituasjonMapperTest {
         // When
         val samboerdetaljer = BosituasjonMapper.map(bosituasjonGifteplaner, dokumenter).verdi.samboerdetaljer
         // Then
-        assertThat(samboerdetaljer?.verdi?.fødselsnummer?.verdi).isNull()
+        assertThat(samboerdetaljer?.verdi?.fødselsnummer?.verdi?.verdi).isEqualTo("26077624804")
     }
 
     @Test
@@ -95,7 +95,7 @@ internal class BosituasjonMapperTest {
         // When
         val samboerdetaljer = BosituasjonMapper.map(bosituasjonGifteplaner, dokumenter).verdi.samboerdetaljer
         // Then
-        assertThat(samboerdetaljer?.verdi?.fødselsdato?.verdi).isNull()
+        assertThat(samboerdetaljer?.verdi?.fødselsdato?.verdi).isEqualTo(LocalDate.parse("1976-07-26"))
     }
 
     private fun getBosituasjon(fileName: String) = objectMapper.readValue(File("src/test/resources/$fileName"),


### PR DESCRIPTION
…adsdialogen

- Map bosituasjon.vordendeSamboer fra søknadsdialog til sivilstandsplaner i kontrakt
- Fjern overflødige sjekker (samboerdetaljer og vordendeSamboer vil nå mappes uavhengig av hverandre)
- Oppdater tester


https://github.com/navikt/familie-kontrakter/pull/306 