### PR TITLE
Fiks feilmelding

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImpl.kt
@@ -46,7 +46,7 @@ internal class OppslagServiceServiceImpl(
     }
 
     private fun throwException() {
-        throw ApiFeil("Personer med tilknytning til søker har adressesperre", HttpStatus.FORBIDDEN)
+        throw ApiFeil("adressesperre", HttpStatus.FORBIDDEN)
     }
 
     private fun validerAdressesperrePåSøkerMedRelasjoner(

--- a/src/test/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImplTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/service/OppslagServiceServiceImplTest.kt
@@ -88,7 +88,7 @@ internal class OppslagServiceServiceImplTest {
         mockHentPersonPdlClient(fornavn = "Et navn", adressebeskyttelseGradering = UGRADERT)
         mockPdlHentBarn(adressebeskyttelseGradering = FORTROLIG)
         val ex = assertThrows<ApiFeil> { oppslagServiceService.hentSøkerinfo() }
-        assertThat(ex.feil).isEqualTo("Personer med tilknytning til søker har adressesperre")
+        assertThat(ex.feil).isEqualTo("adressesperre")
         assertThat(ex.httpStatus).isEqualTo(org.springframework.http.HttpStatus.FORBIDDEN)
     }
 
@@ -97,7 +97,7 @@ internal class OppslagServiceServiceImplTest {
         mockHentPersonPdlClient(fornavn = "Et navn", adressebeskyttelseGradering = UGRADERT)
         mockPdlHentAnnenForelder(adressebeskyttelseGradering = FORTROLIG)
         val ex = assertThrows<ApiFeil> { oppslagServiceService.hentSøkerinfo() }
-        assertThat(ex.feil).isEqualTo("Personer med tilknytning til søker har adressesperre")
+        assertThat(ex.feil).isEqualTo("adressesperre")
         assertThat(ex.httpStatus).isEqualTo(org.springframework.http.HttpStatus.FORBIDDEN)
     }
 
@@ -106,7 +106,7 @@ internal class OppslagServiceServiceImplTest {
         mockHentPersonPdlClient(fornavn = "Et navn", adressebeskyttelseGradering = FORTROLIG)
         mockPdlHentAnnenForelder(adressebeskyttelseGradering = STRENGT_FORTROLIG)
         val ex = assertThrows<ApiFeil> { oppslagServiceService.hentSøkerinfo() }
-        assertThat(ex.feil).isEqualTo("Personer med tilknytning til søker har adressesperre")
+        assertThat(ex.feil).isEqualTo("adressesperre")
         assertThat(ex.httpStatus).isEqualTo(org.springframework.http.HttpStatus.FORBIDDEN)
     }
 
@@ -116,7 +116,7 @@ internal class OppslagServiceServiceImplTest {
         mockHentPersonPdlClient(fornavn = "Et navn", adressebeskyttelseGradering = FORTROLIG)
         mockPdlHentBarn(adressebeskyttelseGradering = STRENGT_FORTROLIG)
         val ex = assertThrows<ApiFeil> { oppslagServiceService.hentSøkerinfo() }
-        assertThat(ex.feil).isEqualTo("Personer med tilknytning til søker har adressesperre")
+        assertThat(ex.feil).isEqualTo("adressesperre")
         assertThat(ex.httpStatus).isEqualTo(org.springframework.http.HttpStatus.FORBIDDEN)
     }
 


### PR DESCRIPTION
Vi gikk over til å heller sette feilmeldingen frontend, så her må man bare sende "adressesperre".