### PR TITLE
bump spring-boot-starter-parent from 2.5.2 to 2.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
 
 
@@ -20,11 +20,11 @@
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
         <jvmTarget>11</jvmTarget>
-        <kotlin.version>1.5.20</kotlin.version>
+        <kotlin.version>1.5.21</kotlin.version>
         <springfox.version>3.0.0</springfox.version>
-        <mockk.version>1.11.0</mockk.version>
+        <mockk.version>1.12.0</mockk.version>
         <token-validation-spring.version>1.3.8</token-validation-spring.version>
-        <fasterxml.version>2.12.3</fasterxml.version>
+        <fasterxml.version>2.12.4</fasterxml.version>
         <felles.version>1.20210510092430_d9bfcd5</felles.version>
         <kontrakter.version>2.0_20210728111441_df460c3</kontrakter.version>
         <start-class>no.nav.familie.ef.søknad.ApplicationKt</start-class>
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
@@ -188,7 +188,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
-            <version>2.28.1</version>
+            <version>2.29.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Samlet noen dependabot oppdateringer

bump wiremock-jre8 from 2.28.1 to 2.29.1

bump commons-io from 2.10.0 to 2.11.0

bump kotlin.version from 1.5.20 to 1.5.21

bump jackson-module-kotlin from 2.12.3 to 2.12.4

bump mockk from 1.11.0 to 1.12.0