### PR TITLE
Fjerner mer unødvendig toggles - ikke i bruk.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/api/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/api/FeatureToggleController.kt
@@ -10,9 +10,7 @@ import org.springframework.web.bind.annotation.*
 @Unprotected
 class FeatureToggleController(private val featureToggleService: FeatureToggleService) {
 
-    val funksjonsbrytere = listOf("familie.ef.soknad.feilsituasjon",
-                                  "familie.ef.soknad.sprakvelger",
-                                  "familie.ef.soknad.visSkalBehandlesINySaksbehandling")
+    val funksjonsbrytere = listOf("familie.ef.soknad.feilsituasjon")
 
     @GetMapping
     fun sjekkAlle(): Map<String, Boolean> {


### PR DESCRIPTION
Disse er fjeret fra frontend - ikke lenger i bruk. 

 "familie.ef.soknad.sprakvelger",
"familie.ef.soknad.visSkalBehandlesINySaksbehandling