### PR TITLE
Skal kun ta med barn som har barnepass

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/mapper/kontrakt/SøknadBarnetilsynMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/mapper/kontrakt/SøknadBarnetilsynMapper.kt
@@ -44,7 +44,7 @@ class SøknadBarnetilsynMapper() {
             medlemskapsdetaljer = MedlemsskapsMapper.map(dto.medlemskap),
             bosituasjon = BosituasjonMapper.map(dto.bosituasjon, vedlegg),
             sivilstandsplaner = SivilstandsplanerMapper.map(dto.bosituasjon),
-            barn = dto.person.barn.tilSøknadsfelt(vedlegg),
+            barn = dto.person.barn.filter { it.skalHaBarnepass?.verdi == true }.tilSøknadsfelt(vedlegg),
             aktivitet = AktivitetsMapper.map(dto.aktivitet, vedlegg),
             stønadsstart = StønadsstartMapper.mapStønadsstart(
                 dto.søknadsdato,

--- a/src/test/kotlin/no/nav/familie/ef/søknad/mapper/SøknadBarnetilsynMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/mapper/SøknadBarnetilsynMapperTest.kt
@@ -1,10 +1,15 @@
 package no.nav.familie.ef.søknad.mapper
 
+import no.nav.familie.ef.søknad.api.dto.søknadsdialog.BooleanFelt
 import no.nav.familie.ef.søknad.api.dto.søknadsdialog.SøknadBarnetilsynDto
+import no.nav.familie.ef.søknad.api.dto.søknadsdialog.TekstFelt
 import no.nav.familie.ef.søknad.mapper.kontrakt.SøknadBarnetilsynMapper
 import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.util.FnrGenerator
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.io.File
+import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.test.assertNotNull
 
@@ -14,14 +19,39 @@ internal class SøknadBarnetilsynMapperTest {
 
     private val innsendingMottatt: LocalDateTime = LocalDateTime.now()
 
+    private val søknad: SøknadBarnetilsynDto = objectMapper.readValue(
+        File("src/test/resources/barnetilsyn/Barnetilsynsøknad.json"),
+        SøknadBarnetilsynDto::class.java,
+    )
+
     @Test
     fun `Barnetilsyn skal mappes `() {
-        val søknad = objectMapper.readValue(
-            File("src/test/resources/barnetilsyn/Barnetilsynsøknad.json"),
-            SøknadBarnetilsynDto::class.java,
-        )
         val mapped = mapper.mapTilIntern(søknad, innsendingMottatt)
 
         assertNotNull(mapped.søknad.barn.verdi.first().navn?.verdi)
+    }
+
+    @Test
+    internal fun `skal kun ta med barn som skal ha barnepass`() {
+        val identForBarnMedBarnepass = FnrGenerator.generer(LocalDate.now())
+        val person = søknad.person
+        val barn = person.barn
+        fun lagBarn(ident: String, skalHaBarnepass: Boolean?) = barn[0]
+            .copy(id = ident, ident = TekstFelt("", ident), skalHaBarnepass = skalHaBarnepass?.let { BooleanFelt("", it) })
+
+        val mapped = mapper.mapTilIntern(
+            søknad.copy(
+                person = person.copy(
+                    barn = listOf(
+                        lagBarn(FnrGenerator.generer(LocalDate.now().minusDays(1)), false),
+                        lagBarn(identForBarnMedBarnepass, true),
+                        lagBarn(FnrGenerator.generer(LocalDate.now().plusDays(1)), null)
+                    )
+                )
+            ), innsendingMottatt
+        )
+        val mappedBarn = mapped.søknad.barn.verdi
+        assertThat(mappedBarn).hasSize(1)
+        assertThat(mappedBarn[0].fødselsnummer?.verdi?.verdi).isEqualTo(identForBarnMedBarnepass)
     }
 }

--- a/src/test/resources/barnetilsyn/Barnetilsynsøknad.json
+++ b/src/test/resources/barnetilsyn/Barnetilsynsøknad.json
@@ -118,7 +118,7 @@
         },
         "skalHaBarnepass": {
           "label": "Skal barnet være med i søknaden?",
-          "verdi": false
+          "verdi": true
         }
       },
       {


### PR DESCRIPTION
* Frontend blir endret om til å sende med alle barnen til backend

#### Hvorfor gjøres dette?
Barn som ikke er valgt i barnetilsyn-søknaden blir borte fra søknaden i steget hvor valgte barn blir oppdatert. Konsekvensen av det er at når man kommer til oppsummering, og skal ende informasjon på barna, er det kun barn som er valgt som er synlig, og det er ingen mulighet til å legge til et av de andre barna. Dette skal nå bli fikset ved at lista med barn ikke oppdateres, og at backend skal filtrere vekk barn som ikke ble valgt i søknaden.

* https://github.com/navikt/familie-ef-soknad/pull/1221

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-9559