### PR TITLE
Skal ta i mot og mappe om informasjon om oppholdsland og land under utenlandsperiode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
         <fasterxml.version>2.14.2</fasterxml.version>
         <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
-        <kontrakter.version>3.0_20230314075921_27fa962-JAKARTA</kontrakter.version>
+        <kontrakter.version>3.0_20230425152938_f30156b-JAKARTA</kontrakter.version>
         <start-class>no.nav.familie.ef.søknad.ApplicationKt</start-class>
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
         <fasterxml.version>2.14.2</fasterxml.version>
         <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
-        <kontrakter.version>3.0_20230425152938_f30156b-JAKARTA</kontrakter.version>
+        <kontrakter.version>3.0_20230428084827_0b6a892-JAKARTA</kontrakter.version>
         <start-class>no.nav.familie.ef.søknad.ApplicationKt</start-class>
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>

--- a/src/main/kotlin/no/nav/familie/ef/søknad/api/dto/søknadsdialog/Medlemskap.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/api/dto/søknadsdialog/Medlemskap.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ef.søknad.api.dto.søknadsdialog
 data class Medlemskap(
     val perioderBoddIUtlandet: List<PerioderBoddIUtlandet>? = listOf(),
     val søkerBosattINorgeSisteTreÅr: BooleanFelt,
-    val oppholdsland: TekstFelt?,
+    val oppholdsland: TekstFelt? = null,
     val søkerOppholderSegINorge: BooleanFelt,
 )
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/api/dto/søknadsdialog/Medlemskap.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/api/dto/søknadsdialog/Medlemskap.kt
@@ -3,10 +3,12 @@ package no.nav.familie.ef.søknad.api.dto.søknadsdialog
 data class Medlemskap(
     val perioderBoddIUtlandet: List<PerioderBoddIUtlandet>? = listOf(),
     val søkerBosattINorgeSisteTreÅr: BooleanFelt,
+    val oppholdsland: TekstFelt?,
     val søkerOppholderSegINorge: BooleanFelt,
 )
 
 data class PerioderBoddIUtlandet(
     val begrunnelse: TekstFelt,
     val periode: PeriodeFelt,
+    val land: TekstFelt?,
 )

--- a/src/main/kotlin/no/nav/familie/ef/søknad/api/dto/søknadsdialog/Medlemskap.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/api/dto/søknadsdialog/Medlemskap.kt
@@ -10,5 +10,5 @@ data class Medlemskap(
 data class PerioderBoddIUtlandet(
     val begrunnelse: TekstFelt,
     val periode: PeriodeFelt,
-    val land: TekstFelt?,
+    val land: TekstFelt? = null,
 )

--- a/src/main/kotlin/no/nav/familie/ef/søknad/mapper/kontrakt/MedlemsskapsMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/mapper/kontrakt/MedlemsskapsMapper.kt
@@ -14,9 +14,10 @@ object MedlemsskapsMapper : Mapper<Medlemskap, Medlemskapsdetaljer>(Språktekste
 
     override fun mapDto(data: Medlemskap): Medlemskapsdetaljer {
         return Medlemskapsdetaljer(
-            data.søkerOppholderSegINorge.tilSøknadsfelt(),
-            data.søkerBosattINorgeSisteTreÅr.tilSøknadsfelt(),
-            Søknadsfelt(
+            oppholderDuDegINorge = data.søkerOppholderSegINorge.tilSøknadsfelt(),
+            oppholdsland = data.oppholdsland?.tilSøknadsfelt(),
+            bosattNorgeSisteÅrene = data.søkerBosattINorgeSisteTreÅr.tilSøknadsfelt(),
+            utenlandsopphold = Søknadsfelt(
                 Språktekster.Utenlandsopphold.hentTekst(),
                 mapUtenlansopphold(data.perioderBoddIUtlandet),
             ),
@@ -26,9 +27,10 @@ object MedlemsskapsMapper : Mapper<Medlemskap, Medlemskapsdetaljer>(Språktekste
     private fun mapUtenlansopphold(perioderBoddIUtlandet: List<PerioderBoddIUtlandet>?): List<KontraksUtenlandsopphold> {
         return perioderBoddIUtlandet?.map { it ->
             KontraksUtenlandsopphold(
-                it.periode.fra.tilSøknadsfelt(),
-                it.periode.til.tilSøknadsfelt(),
-                it.begrunnelse.tilSøknadsfelt(),
+                fradato = it.periode.fra.tilSøknadsfelt(),
+                tildato = it.periode.til.tilSøknadsfelt(),
+                land = it.land?.tilSøknadsfelt(),
+                årsakUtenlandsopphold = it.begrunnelse.tilSøknadsfelt(),
             )
         } ?: listOf()
     }

--- a/src/test/kotlin/no/nav/familie/ef/søknad/mapper/MedlemskapDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/mapper/MedlemskapDtoMapperTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.søknad.mapper
 
 import no.nav.familie.ef.søknad.api.dto.søknadsdialog.BooleanFelt
+import no.nav.familie.ef.søknad.api.dto.søknadsdialog.TekstFelt
 import no.nav.familie.ef.søknad.mapper.kontrakt.MedlemsskapsMapper
 import no.nav.familie.ef.søknad.mock.søknadDto
 import org.assertj.core.api.Assertions.assertThat
@@ -31,10 +32,32 @@ internal class MedlemskapDtoMapperTest {
     }
 
     @Test
+    fun `mapPersonalia mapper dto mapper oppholdsland til null`() {
+        // When
+        val medlemsskapDetaljer = MedlemsskapsMapper.map(medlemskap).verdi
+        // Then
+        assertThat(medlemsskapDetaljer.oppholdsland).isEqualTo(null)
+    }
+
+    @Test
+    fun `mapPersonalia mapper dto mapper oppholdsland til riktige verdier`() {
+        // Given
+        val label = "I hvilket land opphold du og barna dere?"
+        val medlemskap = medlemskap.copy(oppholdsland = TekstFelt(label = label, verdi = "Sverige", svarid = "SWE"))
+        // When
+        val medlemsskapDetaljer = MedlemsskapsMapper.map(medlemskap).verdi
+        // Then
+        assertThat(medlemsskapDetaljer.oppholdsland?.verdi).isEqualTo("Sverige")
+        assertThat(medlemsskapDetaljer.oppholdsland?.svarId).isEqualTo("SWE")
+        assertThat(medlemsskapDetaljer.oppholdsland?.label).isEqualTo(label)
+    }
+
+    @Test
     fun `mapPersonalia mapper perioder bodd i utland`() {
         // When
         val medlemsskapDetaljer = MedlemsskapsMapper.map(medlemskap).verdi
         // Then
         assertThat(medlemsskapDetaljer.utenlandsopphold?.verdi).hasSize(2)
+        assertThat(medlemsskapDetaljer.utenlandsopphold?.verdi?.get(0)?.land?.svarId).isEqualTo("SWE")
     }
 }

--- a/src/test/resources/søknadDto.json
+++ b/src/test/resources/søknadDto.json
@@ -277,6 +277,12 @@
             "verdi": "2019-10-01T08:02:03.000Z"
           }
         },
+        "land": {
+          "spørsmålid": "utenlandsoppholdLand",
+          "svarid": "SWE",
+          "label": "I hvilket land oppholdt du deg?",
+          "verdi": "Sverige"
+        },
         "begrunnelse": {
           "label": "Hvorfor bodde du i utlandet?",
           "verdi": "Jobbet litt"
@@ -293,6 +299,12 @@
             "label": "Til",
             "verdi": "2020-02-01T09:02:03.000Z"
           }
+        },
+        "land": {
+          "spørsmålid": "utenlandsoppholdLand",
+          "svarid": "POL",
+          "label": "I hvilket land oppholdt du deg?",
+          "verdi": "Polen"
         },
         "begrunnelse": {
           "label": "Hvorfor bodde du i utlandet?",


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨ 
[FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12261)
Søknad skal inneholde to nye felter for å registrere hvilket land søker oppholder seg i nå (`oppholdsland`) og hvilket land de oppholdt seg under et utenlandsopphold (`land`) og dette må mappes riktig i API-et slik at det blir sendt med videre. 

### Hva er gjort? 🤓 

- Oppdatert kontrakter versjon
- Lagt de nye feltene inn i mapper

### Hvordan er det testet? 🧪
- Lagd egne tester for feltene
- Lastet opp i preprod og sjekket at feltene følger med til PDF når en søknad sendes inn med de nye feltene

### Andre relevante PR-er 🤝

- ef-soknad [PR 1245](https://github.com/navikt/familie-ef-soknad/pull/1245) (Lagt til de nye feltene)
- ef-sak PR (legger til de nye feltene i søknadsdata)
- familie-kontrakter [PR 744](https://github.com/navikt/familie-kontrakter/pull/774) (legger til oppholdsland i medlemskap og land i utenlandsopphold) og [PR 746](https://github.com/navikt/familie-kontrakter/pull/776) (gi mulighet til å sette de nye feltene i `TestSøknadsBuilder`)
- familie-mottak [PR 964](https://github.com/navikt/familie-ef-mottak/pull/964) (bumper kontrakterversjon)