### PR TITLE
Skal legge ved behandlingsnummer fra behandlingskatalogen i en header…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
         <fasterxml.version>2.15.0</fasterxml.version>
         <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
-        <kontrakter.version>3.0_20230428084827_0b6a892-JAKARTA</kontrakter.version>
+        <kontrakter.version>3.0_20230509152247_36d24db</kontrakter.version>
         <start-class>no.nav.familie.ef.søknad.ApplicationKt</start-class>
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>

--- a/src/main/kotlin/no/nav/familie/ef/søknad/integration/dto/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/integration/dto/pdl/PdlPerson.kt
@@ -6,23 +6,29 @@ import java.time.LocalDate
 data class PdlResponse<T>(
     val data: T,
     val errors: List<PdlError>?,
+    val extensions: PdlExtensions?,
 ) {
 
     fun harFeil(): Boolean {
         return errors != null && errors.isNotEmpty()
     }
-
+    fun harAdvarsel(): Boolean {
+        return !extensions?.warnings.isNullOrEmpty()
+    }
     fun errorMessages(): String {
         return errors?.joinToString { it -> it.message } ?: ""
     }
 }
 
+data class PdlExtensions(val warnings: List<PdlWarning>?)
+data class PdlWarning(val details: Any?, val id: String?, val message: String?, val query: String?)
+
 data class PdlError(
     val message: String,
-    val extensions: PdlExtensions?,
+    val extensions: PdlErrorExtensions?,
 )
 
-data class PdlExtensions(val code: String?) {
+data class PdlErrorExtensions(val code: String?) {
 
     fun notFound() = code == "not_found"
 }
@@ -31,10 +37,13 @@ data class PdlSøkerData(val person: PdlSøker?)
 
 data class PersonDataBolk<T>(val ident: String, val code: String, val person: T?)
 data class PersonBolk<T>(val personBolk: List<PersonDataBolk<T>>)
-data class PdlBolkResponse<T>(val data: PersonBolk<T>?, val errors: List<PdlError>?) {
+data class PdlBolkResponse<T>(val data: PersonBolk<T>?, val errors: List<PdlError>?, val extensions: PdlExtensions?) {
 
     fun errorMessages(): String {
         return errors?.joinToString { it -> it.message } ?: ""
+    }
+    fun harAdvarsel(): Boolean {
+        return !extensions?.warnings.isNullOrEmpty()
     }
 }
 

--- a/src/test/kotlin/no/nav/familie/ef/søknad/mapper/FeltMapperUtilKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/mapper/FeltMapperUtilKtTest.kt
@@ -92,7 +92,7 @@ internal class FeltMapperUtilKtTest {
         assertEquals(123, "123,99".tilHeltall())
     }
 
-    /* TekstFelt -> Dato */
+    // TekstFelt -> Dato
 
     @Test
     internal fun `Tekst til dato -skal tåle tom streng og returnere null`() {
@@ -112,7 +112,7 @@ internal class FeltMapperUtilKtTest {
         assertEquals(felt?.verdi, LocalDate.of(2020, 3, 4))
     }
 
-    /* Spesielle tilfeller */
+    // Spesielle tilfeller
 
     // Her er jeg usikker på hva som kan ha skjedd - UI feil?
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/søknad/mapper/SøknadBarnetilsynMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/mapper/SøknadBarnetilsynMapperTest.kt
@@ -45,10 +45,11 @@ internal class SøknadBarnetilsynMapperTest {
                     barn = listOf(
                         lagBarn(FnrGenerator.generer(LocalDate.now().minusDays(1)), false),
                         lagBarn(identForBarnMedBarnepass, true),
-                        lagBarn(FnrGenerator.generer(LocalDate.now().plusDays(1)), null)
-                    )
-                )
-            ), innsendingMottatt
+                        lagBarn(FnrGenerator.generer(LocalDate.now().plusDays(1)), null),
+                    ),
+                ),
+            ),
+            innsendingMottatt,
         )
         val mappedBarn = mapped.søknad.barn.verdi
         assertThat(mappedBarn).hasSize(1)


### PR DESCRIPTION
… ved kall til PDL. Datatyper for PdlExtensions og PdlWarning, og logging av warnings.

Hvorfor ?

PDL gjør endringer mot en mere fingranulert tilgangsstyring, og ønsker at konsumentene skal legge på en header med behandlingsnummer fra enhetskatalogen. Vi ønsker også å logge advarsler fra PDL, og ikke bare feil.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12402