### PR TITLE
Legger på flere behandlingsnummer headere i PDL klienter da det mangl…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/integration/PdlApp2AppClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/integration/PdlApp2AppClient.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ef.søknad.integration.dto.pdl.PdlBolkResponse
 import no.nav.familie.ef.søknad.integration.dto.pdl.PdlPersonBolkRequest
 import no.nav.familie.ef.søknad.integration.dto.pdl.PdlPersonBolkRequestVariables
 import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.kontrakter.felles.Tema
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpHeaders
@@ -54,6 +55,7 @@ class PdlApp2AppClient(
     private fun httpHeaders(): HttpHeaders {
         return HttpHeaders().apply {
             add("Tema", "ENF")
+            add("behandlingsnummer", Tema.ENF.behandlingsnummer)
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/integration/SøknadClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/integration/SøknadClient.kt
@@ -12,6 +12,7 @@ import no.nav.familie.kontrakter.ef.søknad.SøknadMedVedlegg
 import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønad
 import no.nav.familie.kontrakter.ef.søknad.SøknadSkolepenger
 import no.nav.familie.kontrakter.felles.PersonIdent
+import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpHeaders
@@ -68,6 +69,7 @@ class SøknadClient(
 
     private fun HttpHeaders.medContentTypeJsonUTF8(): HttpHeaders {
         this.add("Content-Type", "application/json;charset=UTF-8")
+        this.add("behandlingsnummer", Tema.ENF.behandlingsnummer)
         this.acceptCharset = listOf(Charsets.UTF_8)
         return this
     }


### PR DESCRIPTION
…et et par av disse

Hvorfor ? 

Har fått noen warnings i logger fordi det ikke er lagt til en behandlingsnummer header i to av PDL klientene. Måtte derfor legge til headeren også i disse (SøknadClient og PdlApp2AppClient). 

Warnings : 
Advarsel ved henting av class no.nav.familie.ef.søknad.integration.dto.pdl.PdlAnnenForelder fra PDL - familie-ef-soknad-api
Advarsel ved henting av class no.nav.familie.ef.søknad.integration.dto.pdl.PdlBarn fra PDL - familie-ef-soknad-api

Favro : https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12402