### PR TITLE
build(deps): bump maven-surefire-plugin from 3.0.0 to 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.6</version>
+        <version>3.1.0</version>
     </parent>
 
 
@@ -19,13 +19,13 @@
         <revision>1.0</revision>
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
-        <kotlin.version>1.8.21</kotlin.version>
+        <kotlin.version>1.8.22</kotlin.version>
         <springdoc.version>2.1.0</springdoc.version>
         <mockk.version>1.13.5</mockk.version>
-        <token-validation-spring.version>3.0.12</token-validation-spring.version>
+        <token-validation-spring.version>3.1.0</token-validation-spring.version>
         <okhttp3.version>4.9.1</okhttp3.version> <!-- overskriver spring sin versjon, blir brukt av mock-oauth2-server -->
 
-        <fasterxml.version>2.15.0</fasterxml.version>
+        <fasterxml.version>2.15.2</fasterxml.version>
         <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
         <kontrakter.version>3.0_20230509152247_36d24db</kontrakter.version>
         <start-class>no.nav.familie.ef.søknad.ApplicationKt</start-class>
@@ -297,7 +297,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>make-assembly</id>
@@ -322,7 +322,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -365,7 +365,7 @@
                     <dependency>
                         <groupId>com.pinterest</groupId>
                         <artifactId>ktlint</artifactId>
-                        <version>0.49.0</version>
+                        <version>0.49.1</version>
                     </dependency>
                     <!-- additional 3rd party ruleset(s) can be specified here -->
                 </dependencies>


### PR DESCRIPTION
build(deps): bump kotlin.version from 1.8.21 to 1.8.22

build(deps): bump jackson-module-kotlin from 2.15.0 to 2.15.2

build(deps): bump token-validation-spring.version from 3.0.12 to 3.1.0

build(deps): bump spring-boot-starter-parent from 3.0.6 to 3.1.0

build(deps): bump maven-assembly-plugin from 3.5.0 to 3.6.0

build(deps): bump ktlint from 0.49.0 to 0.49.1