### PR TITLE
Fjerner CPU-limit

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -23,11 +23,9 @@ spec:
   replicas:
     min: 2
     max: 4
-    cpuThresholdPercentage: 50
   resources:
     limits:
       memory: 2Gi
-      cpu: "1"
     requests:
       memory: 1Gi
       cpu: 500m

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -23,11 +23,9 @@ spec:
   replicas:
     min: 2
     max: 4
-    cpuThresholdPercentage: 50
   resources:
     limits:
       memory: 2Gi
-      cpu: "1"
     requests:
       memory: 1Gi
       cpu: 500m


### PR DESCRIPTION
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver godt hvorfor:
https://home.robusta.dev/blog/stop-using-cpu-limits

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)