### PR TITLE
Vil fjerne loginservice-idporten somikke er i bruk.

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -52,7 +52,6 @@ spec:
         - host: pdl-api.dev-fss-pub.nais.io
         - host: familie-ef-mottak.dev-fss-pub.nais.io
   envFrom:
-    - configmap: loginservice-idporten
     - secret: familie
     - secret: ef-soknad-api
   env:

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -52,7 +52,6 @@ spec:
         - host: pdl-api.prod-fss-pub.nais.io
         - host: familie-ef-mottak.prod-fss-pub.nais.io
   envFrom:
-    - configmap: loginservice-idporten
     - secret: familie
     - secret: ef-soknad-api
   env:


### PR DESCRIPTION
[Se diskusjon
](https://nav-it.slack.com/archives/CJN0STWB0/p1693384605818509)

>Restene av Loginservice forsvinner (etterhvert)
Til slutt minner vi om at de siste restene av Loginservice forsvinner i løpet av året. Om dere bruker noe av dette så bør dere begynne å legge planer om å slutte med det:
Ingressene [loginservice.intern.dev.nav.no](http://loginservice.intern.dev.nav.no/) og [loginservice.nav.no](http://loginservice.nav.no/) slutter å fungere
ConfigMap-et loginservice-idporten forsvinner
Cookien selvbetjening-idtoken blir ikke lenger satt

Deployet branch og testet innsendinga av søknad i preprod.
