### PR TITLE
Map skal ha barnepass slik at barn blir automatisk huket av ved gjenbruk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/mapper/kontrakt/BarnMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/mapper/kontrakt/BarnMapper.kt
@@ -66,7 +66,7 @@ object BarnMapper : MapperMedVedlegg<List<Barn>, List<Kontraktbarn>>(BarnaDine) 
                     it.samvær?.verdi,
                     it.skalBarnetBoHosSøker,
                 ),
-                skalHaBarnepass = null,
+                skalHaBarnepass = it.skalHaBarnepass.tilNullableBooleanFelt(),
                 særligeTilsynsbehov = it.særligeTilsynsbehov.tilNullableTekstFelt(),
                 barnepass = null,
             )


### PR DESCRIPTION
Barnepass ble ikke mappet slik at barn ikke ble huket av automatisk ved gjenbruk. Det er ønskelig at de blir det.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-17705)