### PR TITLE
Hvorforikkeoppgi navn gjenbruk endring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
@@ -165,7 +165,7 @@ object BarnMapper : MapperMedVedlegg<List<Barn>, List<Kontraktbarn>>(BarnaDine) 
 
     private fun hvorforIkkeOppgiSvarIdBasertPåBegrunnelse(begrunnelse: String?): String? {
         return when {
-            begrunnelse == "Donor" -> "donorBarn"
+            begrunnelse == "Donor" -> "donorbarn"
             begrunnelse.erIkkeBlankEllerNull() -> "annet"
             else -> null
         }

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
@@ -183,7 +183,7 @@ object BarnMapper : MapperMedVedlegg<List<Barn>, List<Kontraktbarn>>(BarnaDine) 
     }
 
     private fun søknadsfeltTilNullEllerNullableTekstFelt(søknadsFelt: Søknadsfelt<String>?): TekstFelt? {
-        return if (!søknadsFelt?.verdi.isNullOrBlank()) {
+        return if (søknadsFelt?.verdi.isNullOrBlank() || søknadsFelt?.verdi == Språktekster.IkkeOppgitt.hentTekst()) {
             null
         } else {
             søknadsFelt.tilNullableTekstFelt()

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
@@ -136,7 +136,7 @@ object BarnMapper : MapperMedVedlegg<List<Barn>, List<Kontraktbarn>>(BarnaDine) 
                     it.verdi,
                 )
             },
-            navn = annenForelder.person?.verdi?.navn.tilNullableTekstFelt(),
+            navn = søknadsfeltTilNullEllerNullableTekstFelt(annenForelder.person?.verdi?.navn),
             fødselsdato = annenForelder.person?.verdi?.fødselsdato.tilNullableDatoFelt(),
             ident = annenForelder.person?.verdi?.fødselsnummer.fødselsnummerTilTekstFelt(),
             borINorge = annenForelder.bosattNorge.tilNullableBooleanFelt(),
@@ -163,14 +163,31 @@ object BarnMapper : MapperMedVedlegg<List<Barn>, List<Kontraktbarn>>(BarnaDine) 
         }
     }
 
+    private fun hvorforIkkeOppgiSvarIdBasertPåBegrunnelse(begrunnelse: String?): String? {
+        return when {
+            begrunnelse == "Donor" -> "donorBarn"
+            begrunnelse.erIkkeBlankEllerNull() -> "annet"
+            else -> null
+        }
+    }
+
     private fun String?.erIkkeBlankEllerNull() = !this.isNullOrBlank()
 
     private fun hvorforIkkeOppgiTilTekstfeltEllerNullBasertPåBegrunnelse(begrunnelse: String?): TekstFelt? {
         val hvorforIkkeOppgi = hvorforIkkeOppgiBasertPåBegrunnelse(begrunnelse)
-        if (hvorforIkkeOppgi != null) {
-            return TekstFelt("Hvorfor kan du ikke oppgi den andre forelderen?", hvorforIkkeOppgi)
+        val svarId = hvorforIkkeOppgiSvarIdBasertPåBegrunnelse(begrunnelse)
+        if (hvorforIkkeOppgi != null && svarId != null) {
+            return TekstFelt("Hvorfor kan du ikke oppgi den andre forelderen?", hvorforIkkeOppgi, svarId)
         }
         return null
+    }
+
+    private fun søknadsfeltTilNullEllerNullableTekstFelt(søknadsFelt: Søknadsfelt<String>?): TekstFelt? {
+        return if (!søknadsFelt?.verdi.isNullOrBlank()) {
+            null
+        } else {
+            søknadsFelt.tilNullableTekstFelt()
+        }
     }
 
     private fun mapSamvær(

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
@@ -136,7 +136,7 @@ object BarnMapper : MapperMedVedlegg<List<Barn>, List<Kontraktbarn>>(BarnaDine) 
                     it.verdi,
                 )
             },
-            navn = søknadsfeltTilNullEllerNullableTekstFelt(annenForelder.person?.verdi?.navn),
+            navn = lagNullableTekstfeltAvNavnHvisHvorforIkkeOppgiManglerVerdi(annenForelder),
             fødselsdato = annenForelder.person?.verdi?.fødselsdato.tilNullableDatoFelt(),
             ident = annenForelder.person?.verdi?.fødselsnummer.fødselsnummerTilTekstFelt(),
             borINorge = annenForelder.bosattNorge.tilNullableBooleanFelt(),
@@ -182,11 +182,11 @@ object BarnMapper : MapperMedVedlegg<List<Barn>, List<Kontraktbarn>>(BarnaDine) 
         return null
     }
 
-    private fun søknadsfeltTilNullEllerNullableTekstFelt(søknadsFelt: Søknadsfelt<String>?): TekstFelt? {
-        return if (søknadsFelt?.verdi.isNullOrBlank() || søknadsFelt?.verdi == Språktekster.IkkeOppgitt.hentTekst()) {
+    private fun lagNullableTekstfeltAvNavnHvisHvorforIkkeOppgiManglerVerdi(annenForelder: AnnenForelder?): TekstFelt? {
+        return if (annenForelder?.ikkeOppgittAnnenForelderBegrunnelse?.verdi != null) {
             null
         } else {
-            søknadsFelt.tilNullableTekstFelt()
+            annenForelder?.person?.verdi?.navn.tilNullableTekstFelt()
         }
     }
 


### PR DESCRIPTION
- Ønsker å sende med hvorforIkkeOppgi svarid fra api, dette blir nå utledet og sendt med.
- Annen forelder navn skal ikke sendes med hivs hvorforIkkeOppgiBegrunnelse har en verdi (det er valgt annet eller donor på annen forelder)

[Søknad](https://github.com/navikt/familie-ef-soknad/pull/1617)