### PR TITLE
Fjerner toggle for gjenbruk av BT søknad da dette alltid skal være på.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -17,7 +17,6 @@ class FeatureToggleController(private val featureToggleService: FeatureToggleSer
         "familie.ef.soknad.feilsituasjon",
         "familie.ef.soknad.nynorsk",
         "familie.ef.soknad.validerbosituasjon",
-        "familie.ef.soknad.hent-barnetilsyn-soknad-til-gjenbruk",
     )
 
     @GetMapping


### PR DESCRIPTION
[Fjernet i frontend](https://github.com/navikt/familie-ef-soknad/pull/1634)