### PR TITLE
spm om terminbekreftelse kommer kun ved ufødt barn

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.søknad.søknad.mapper
 
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Metrics
+import no.nav.familie.ef.søknad.person.mapper.PersonMinimumMapper
 import no.nav.familie.ef.søknad.søknad.domain.Barn
 import no.nav.familie.ef.søknad.søknad.domain.BooleanFelt
 import no.nav.familie.ef.søknad.søknad.domain.DokumentIdentifikator.BARN_BOR_HOS_SØKER
@@ -113,6 +114,7 @@ object BarnMapper : MapperMedVedlegg<List<Barn>, List<Søknadbarn>>(BarnaDine) {
                 ikkeOppgittAnnenForelderBegrunnelse = forelder.ikkeOppgittAnnenForelderBegrunnelse?.tilSøknadsfelt(),
                 bosattNorge = forelder.borINorge?.tilSøknadsfelt(),
                 land = forelder.land?.tilSøknadsfelt(),
+                person = PersonMinimumMapper.map(forelder),
             ),
         )
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
@@ -5,7 +5,9 @@ import io.micrometer.core.instrument.Metrics
 import no.nav.familie.ef.søknad.person.mapper.PersonMinimumMapper
 import no.nav.familie.ef.søknad.søknad.domain.Barn
 import no.nav.familie.ef.søknad.søknad.domain.BooleanFelt
-import no.nav.familie.ef.søknad.søknad.domain.DokumentIdentifikator.*
+import no.nav.familie.ef.søknad.søknad.domain.DokumentIdentifikator.SAMVÆRSAVTALE
+import no.nav.familie.ef.søknad.søknad.domain.DokumentIdentifikator.TERMINBEKREFTELSE
+import no.nav.familie.ef.søknad.søknad.domain.DokumentIdentifikator.BARN_BOR_HOS_SØKER
 import no.nav.familie.ef.søknad.søknad.domain.TekstFelt
 import no.nav.familie.ef.søknad.utils.DokumentasjonWrapper
 import no.nav.familie.ef.søknad.utils.DokumentfeltUtil.dokumentfelt
@@ -95,7 +97,10 @@ object BarnMapper : MapperMedVedlegg<List<Barn>, List<Søknadbarn>>(BarnaDine) {
         skalBarnetBoHosSøker = barn.forelder?.skalBarnetBoHosSøker?.tilSøknadsfelt(),
     )
 
-    private fun mapTerminbekreftelse(barn: Barn, vedlegg: Map<String, DokumentasjonWrapper>) = if (!barn.født.verdi) dokumentfelt(TERMINBEKREFTELSE, vedlegg) else null
+    private fun mapTerminbekreftelse(
+        barn: Barn,
+        vedlegg: Map<String, DokumentasjonWrapper>,
+    ) = if (!barn.født.verdi) dokumentfelt(TERMINBEKREFTELSE, vedlegg) else null
 
     private fun mapFødselsnummer(barn: Barn): Søknadsfelt<Fødselsnummer>? {
         return barn.ident?.let {

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
@@ -2,12 +2,10 @@ package no.nav.familie.ef.søknad.søknad.mapper
 
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Metrics
-import no.nav.familie.ef.søknad.person.mapper.PersonMinimumMapper
 import no.nav.familie.ef.søknad.søknad.domain.Barn
 import no.nav.familie.ef.søknad.søknad.domain.BooleanFelt
 import no.nav.familie.ef.søknad.søknad.domain.DokumentIdentifikator.BARN_BOR_HOS_SØKER
 import no.nav.familie.ef.søknad.søknad.domain.DokumentIdentifikator.SAMVÆRSAVTALE
-import no.nav.familie.ef.søknad.søknad.domain.DokumentIdentifikator.TERMINBEKREFTELSE
 import no.nav.familie.ef.søknad.søknad.domain.TekstFelt
 import no.nav.familie.ef.søknad.utils.DokumentasjonWrapper
 import no.nav.familie.ef.søknad.utils.DokumentfeltUtil.dokumentfelt
@@ -20,6 +18,7 @@ import no.nav.familie.ef.søknad.utils.tilNullableDatoFelt
 import no.nav.familie.ef.søknad.utils.tilNullableTekstFelt
 import no.nav.familie.ef.søknad.utils.tilSøknadsDatoFeltEllerNull
 import no.nav.familie.ef.søknad.utils.tilSøknadsfelt
+import no.nav.familie.ef.søknad.utils.tilTerminbekreftelseDokumentasjonEllerNull
 import no.nav.familie.kontrakter.ef.søknad.AnnenForelder
 import no.nav.familie.kontrakter.ef.søknad.Samvær
 import no.nav.familie.kontrakter.ef.søknad.Søknadsfelt
@@ -87,7 +86,7 @@ object BarnMapper : MapperMedVedlegg<List<Barn>, List<Søknadbarn>>(BarnaDine) {
                 ?.tilSøknadsfelt(),
         erBarnetFødt = barn.født.tilSøknadsfelt(),
         fødselTermindato = barn.fødselsdato?.tilSøknadsDatoFeltEllerNull(),
-        terminbekreftelse = dokumentfelt(TERMINBEKREFTELSE, vedlegg),
+        terminbekreftelse = barn.født.tilTerminbekreftelseDokumentasjonEllerNull(vedlegg),
         annenForelder = barn.forelder?.let { mapAnnenForelder(it) },
         samvær = barn.forelder?.let { mapSamvær(it, vedlegg) },
         skalHaBarnepass = barn.skalHaBarnepass?.tilSøknadsfelt(),
@@ -114,7 +113,6 @@ object BarnMapper : MapperMedVedlegg<List<Barn>, List<Søknadbarn>>(BarnaDine) {
                 ikkeOppgittAnnenForelderBegrunnelse = forelder.ikkeOppgittAnnenForelderBegrunnelse?.tilSøknadsfelt(),
                 bosattNorge = forelder.borINorge?.tilSøknadsfelt(),
                 land = forelder.land?.tilSøknadsfelt(),
-                person = PersonMinimumMapper.map(forelder),
             ),
         )
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapper.kt
@@ -5,8 +5,7 @@ import io.micrometer.core.instrument.Metrics
 import no.nav.familie.ef.søknad.person.mapper.PersonMinimumMapper
 import no.nav.familie.ef.søknad.søknad.domain.Barn
 import no.nav.familie.ef.søknad.søknad.domain.BooleanFelt
-import no.nav.familie.ef.søknad.søknad.domain.DokumentIdentifikator.BARN_BOR_HOS_SØKER
-import no.nav.familie.ef.søknad.søknad.domain.DokumentIdentifikator.SAMVÆRSAVTALE
+import no.nav.familie.ef.søknad.søknad.domain.DokumentIdentifikator.*
 import no.nav.familie.ef.søknad.søknad.domain.TekstFelt
 import no.nav.familie.ef.søknad.utils.DokumentasjonWrapper
 import no.nav.familie.ef.søknad.utils.DokumentfeltUtil.dokumentfelt
@@ -19,7 +18,6 @@ import no.nav.familie.ef.søknad.utils.tilNullableDatoFelt
 import no.nav.familie.ef.søknad.utils.tilNullableTekstFelt
 import no.nav.familie.ef.søknad.utils.tilSøknadsDatoFeltEllerNull
 import no.nav.familie.ef.søknad.utils.tilSøknadsfelt
-import no.nav.familie.ef.søknad.utils.tilTerminbekreftelseDokumentasjonEllerNull
 import no.nav.familie.kontrakter.ef.søknad.AnnenForelder
 import no.nav.familie.kontrakter.ef.søknad.Samvær
 import no.nav.familie.kontrakter.ef.søknad.Søknadsfelt
@@ -87,7 +85,7 @@ object BarnMapper : MapperMedVedlegg<List<Barn>, List<Søknadbarn>>(BarnaDine) {
                 ?.tilSøknadsfelt(),
         erBarnetFødt = barn.født.tilSøknadsfelt(),
         fødselTermindato = barn.fødselsdato?.tilSøknadsDatoFeltEllerNull(),
-        terminbekreftelse = barn.født.tilTerminbekreftelseDokumentasjonEllerNull(vedlegg),
+        terminbekreftelse = mapTerminbekreftelse(barn, vedlegg),
         annenForelder = barn.forelder?.let { mapAnnenForelder(it) },
         samvær = barn.forelder?.let { mapSamvær(it, vedlegg) },
         skalHaBarnepass = barn.skalHaBarnepass?.tilSøknadsfelt(),
@@ -96,6 +94,8 @@ object BarnMapper : MapperMedVedlegg<List<Barn>, List<Søknadbarn>>(BarnaDine) {
         lagtTilManuelt = barn.lagtTil,
         skalBarnetBoHosSøker = barn.forelder?.skalBarnetBoHosSøker?.tilSøknadsfelt(),
     )
+
+    private fun mapTerminbekreftelse(barn: Barn, vedlegg: Map<String, DokumentasjonWrapper>) = if (!barn.født.verdi) dokumentfelt(TERMINBEKREFTELSE, vedlegg) else null
 
     private fun mapFødselsnummer(barn: Barn): Søknadsfelt<Fødselsnummer>? {
         return barn.ident?.let {

--- a/src/main/kotlin/no/nav/familie/ef/søknad/utils/FeltMapperUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/utils/FeltMapperUtil.kt
@@ -2,13 +2,11 @@ package no.nav.familie.ef.søknad.utils
 
 import no.nav.familie.ef.søknad.søknad.domain.BooleanFelt
 import no.nav.familie.ef.søknad.søknad.domain.DatoFelt
-import no.nav.familie.ef.søknad.søknad.domain.DokumentIdentifikator.TERMINBEKREFTELSE
 import no.nav.familie.ef.søknad.søknad.domain.Dokumentasjonsbehov
 import no.nav.familie.ef.søknad.søknad.domain.HeltallFelt
 import no.nav.familie.ef.søknad.søknad.domain.ListFelt
 import no.nav.familie.ef.søknad.søknad.domain.PeriodeFelt
 import no.nav.familie.ef.søknad.søknad.domain.TekstFelt
-import no.nav.familie.ef.søknad.utils.DokumentfeltUtil.dokumentfelt
 import no.nav.familie.kontrakter.ef.søknad.Dokument
 import no.nav.familie.kontrakter.ef.søknad.MånedÅrPeriode
 import no.nav.familie.kontrakter.ef.søknad.Søknadsfelt
@@ -81,13 +79,6 @@ fun DatoFelt.tilSøknadsDatoFeltEllerNull(): Søknadsfelt<LocalDate>? =
         Søknadsfelt(this.label, fraStrengTilLocalDate(verdi))
     } else {
         null
-    }
-
-fun BooleanFelt.tilTerminbekreftelseDokumentasjonEllerNull(vedlegg: Map<String, DokumentasjonWrapper>) =
-    if (this.verdi) {
-        null
-    } else {
-        dokumentfelt(TERMINBEKREFTELSE, vedlegg)
     }
 
 fun DatoFelt.tilSøknadsfelt(): Søknadsfelt<LocalDate> {

--- a/src/main/kotlin/no/nav/familie/ef/søknad/utils/FeltMapperUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/utils/FeltMapperUtil.kt
@@ -2,11 +2,13 @@ package no.nav.familie.ef.søknad.utils
 
 import no.nav.familie.ef.søknad.søknad.domain.BooleanFelt
 import no.nav.familie.ef.søknad.søknad.domain.DatoFelt
+import no.nav.familie.ef.søknad.søknad.domain.DokumentIdentifikator.TERMINBEKREFTELSE
 import no.nav.familie.ef.søknad.søknad.domain.Dokumentasjonsbehov
 import no.nav.familie.ef.søknad.søknad.domain.HeltallFelt
 import no.nav.familie.ef.søknad.søknad.domain.ListFelt
 import no.nav.familie.ef.søknad.søknad.domain.PeriodeFelt
 import no.nav.familie.ef.søknad.søknad.domain.TekstFelt
+import no.nav.familie.ef.søknad.utils.DokumentfeltUtil.dokumentfelt
 import no.nav.familie.kontrakter.ef.søknad.Dokument
 import no.nav.familie.kontrakter.ef.søknad.MånedÅrPeriode
 import no.nav.familie.kontrakter.ef.søknad.Søknadsfelt
@@ -79,6 +81,13 @@ fun DatoFelt.tilSøknadsDatoFeltEllerNull(): Søknadsfelt<LocalDate>? =
         Søknadsfelt(this.label, fraStrengTilLocalDate(verdi))
     } else {
         null
+    }
+
+fun BooleanFelt.tilTerminbekreftelseDokumentasjonEllerNull(vedlegg: Map<String, DokumentasjonWrapper>) =
+    if (this.verdi) {
+        null
+    } else {
+        dokumentfelt(TERMINBEKREFTELSE, vedlegg)
     }
 
 fun DatoFelt.tilSøknadsfelt(): Søknadsfelt<LocalDate> {

--- a/src/test/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/søknad/mapper/BarnMapperTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.søknad.søknad.mapper
 
 import no.nav.familie.ef.søknad.mock.søknadDto
+import no.nav.familie.ef.søknad.søknad.domain.BooleanFelt
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -11,8 +12,10 @@ internal class BarnMapperTest {
     private val søknadDto = søknadDto()
 
     // Når
+    private val terminbarnSøknad = søknadDto.person.barn.first().copy(født = BooleanFelt("Er barnet født", verdi = false), lagtTil = true)
     private val folkeregistrerteBarn = BarnMapper.map(søknadDto.person.barn, dokumenter).verdi.first()
     private val nyregistrertBarn = BarnMapper.map(søknadDto.person.barn, dokumenter).verdi[1]
+    private val terminbarn = BarnMapper.map(listOf(terminbarnSøknad), dokumenter).verdi.first()
 
     @Test
     fun `Folkeregistrert barn har riktig fødselsnummer`() {
@@ -71,5 +74,12 @@ internal class BarnMapperTest {
     @Test
     fun `SærligeTilsynsbehov må ha verdi`() {
         assertThat(folkeregistrerteBarn.særligeTilsynsbehov?.verdi).isEqualTo("Har jo fort litt særlige tilsynsbehov da!")
+    }
+
+    @Test
+    fun `terminbarn skal mappe terminbekreftelse, mens fødte barn skal ikke ha terminbekreftelse`() {
+        assertThat(terminbarn.terminbekreftelse).isNotNull()
+        assertThat(folkeregistrerteBarn.terminbekreftelse).isNull()
+        assertThat(nyregistrertBarn.terminbekreftelse).isNull()
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/søknad/søknad/mapper/KontraktDto.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/søknad/mapper/KontraktDto.kt
@@ -29,5 +29,6 @@ fun adresseSøknadsfelt(): Søknadsfelt<Adresse> =
 
 fun dokumentMap(): Map<String, DokumentasjonWrapper> {
     val vedlegg = Vedlegg("id", "navn", "tittel")
-    return mapOf("samlivsbrudd" to DokumentasjonWrapper("label", Søknadsfelt("Har allerede sendt inn", false), listOf(vedlegg)))
+    return mapOf("samlivsbrudd" to DokumentasjonWrapper("label", Søknadsfelt("Har allerede sendt inn", false), listOf(vedlegg)),
+        "TERMINBEKREFTELSE" to DokumentasjonWrapper("Terminbekreftelse", Søknadsfelt("Har allerede sendt inn", false), listOf(vedlegg)))
 }

--- a/src/test/kotlin/no/nav/familie/ef/søknad/utils/FeltMapperUtilKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/utils/FeltMapperUtilKtTest.kt
@@ -135,19 +135,4 @@ internal class FeltMapperUtilKtTest {
     internal fun `Tekst til dato - skal gjøre om tekst med zone data`() {
         assertThrows<DateTimeParseException> { DatoFelt("label", "2007-04-05T23:59+02:00").tilSøknadsDatoFeltEllerNull() }
     }
-
-    @Test
-    internal fun `Barn som er født skal returnere null istedenfor terminbekreftelse`() {
-        val vedlegg = mapOf<String, DokumentasjonWrapper>()
-        val felt = BooleanFelt("label", true).tilTerminbekreftelseDokumentasjonEllerNull(vedlegg)
-        assertEquals(felt?.verdi, null)
-    }
-
-    @Test
-    internal fun `Barn som ikke er født skal returnere terminbekreftelse`() {
-        val vedlegg = mapOf<String, DokumentasjonWrapper>()
-        val felt = BooleanFelt("label", false).tilTerminbekreftelseDokumentasjonEllerNull(vedlegg)
-        assertEquals(felt?.verdi, dokumentfelt(TERMINBEKREFTELSE, vedlegg))
-    }
-
 }

--- a/src/test/kotlin/no/nav/familie/ef/søknad/utils/FeltMapperUtilKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/utils/FeltMapperUtilKtTest.kt
@@ -2,9 +2,11 @@ package no.nav.familie.ef.søknad.utils
 
 import no.nav.familie.ef.søknad.søknad.domain.BooleanFelt
 import no.nav.familie.ef.søknad.søknad.domain.DatoFelt
+import no.nav.familie.ef.søknad.søknad.domain.DokumentIdentifikator.TERMINBEKREFTELSE
 import no.nav.familie.ef.søknad.søknad.domain.ListFelt
 import no.nav.familie.ef.søknad.søknad.domain.PeriodeFelt
 import no.nav.familie.ef.søknad.søknad.domain.TekstFelt
+import no.nav.familie.ef.søknad.utils.DokumentfeltUtil.dokumentfelt
 import no.nav.familie.kontrakter.ef.søknad.MånedÅrPeriode
 import no.nav.familie.kontrakter.ef.søknad.Søknadsfelt
 import no.nav.familie.kontrakter.felles.Fødselsnummer
@@ -133,4 +135,19 @@ internal class FeltMapperUtilKtTest {
     internal fun `Tekst til dato - skal gjøre om tekst med zone data`() {
         assertThrows<DateTimeParseException> { DatoFelt("label", "2007-04-05T23:59+02:00").tilSøknadsDatoFeltEllerNull() }
     }
+
+    @Test
+    internal fun `Barn som er født skal returnere null istedenfor terminbekreftelse`() {
+        val vedlegg = mapOf<String, DokumentasjonWrapper>()
+        val felt = BooleanFelt("label", true).tilTerminbekreftelseDokumentasjonEllerNull(vedlegg)
+        assertEquals(felt?.verdi, null)
+    }
+
+    @Test
+    internal fun `Barn som ikke er født skal returnere terminbekreftelse`() {
+        val vedlegg = mapOf<String, DokumentasjonWrapper>()
+        val felt = BooleanFelt("label", false).tilTerminbekreftelseDokumentasjonEllerNull(vedlegg)
+        assertEquals(felt?.verdi, dokumentfelt(TERMINBEKREFTELSE, vedlegg))
+    }
+
 }


### PR DESCRIPTION
Tidligere dukket det opp "Jeg har send inn denne dokumentasjonent il NAV tidligere" på alle barn, dersom én av barnene i søknaden ikke var født. Nå dukker "Jeg har send inn denne dokumentasjonent il NAV tidligere" (terminbekreftelsen) kun opp på barnet som ikke er født.

Gammelt:
![image](https://github.com/user-attachments/assets/212bcb35-6231-4340-9959-f5baad9d12ba)

Nytt:
![image](https://github.com/user-attachments/assets/97d314b7-a4d6-4a71-a52a-a261010d3282)
