### PR TITLE
Sjekker om verdier er tomme strenger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/MedlemsskapsMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/MedlemsskapsMapper.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ef.søknad.utils.Språktekster
 import no.nav.familie.ef.søknad.utils.hentTekst
 import no.nav.familie.ef.søknad.utils.tilNullableTekstFelt
 import no.nav.familie.ef.søknad.utils.tilSøknadsfelt
+import no.nav.familie.ef.søknad.utils.tilSøknadsfeltEllerNull
 import no.nav.familie.kontrakter.ef.søknad.Medlemskapsdetaljer
 import no.nav.familie.kontrakter.ef.søknad.Søknadsfelt
 import no.nav.familie.kontrakter.ef.søknad.Utenlandsopphold as KontraksUtenlandsopphold
@@ -34,8 +35,8 @@ object MedlemsskapsMapper : Mapper<Medlemskap, Medlemskapsdetaljer>(Språktekste
                 tildato = it.periode.til.tilSøknadsfelt(),
                 land = it.land?.tilSøknadsfelt(),
                 årsakUtenlandsopphold = it.begrunnelse.tilSøknadsfelt(),
-                personidentEøsLand = it.personidentEøsLand?.tilSøknadsfelt(),
-                adresseEøsLand = it.adresseEøsLand?.tilSøknadsfelt(),
+                personidentEøsLand = it.personidentEøsLand?.tilSøknadsfeltEllerNull(),
+                adresseEøsLand = it.adresseEøsLand?.tilSøknadsfeltEllerNull(),
                 erEøsLand = it.erEøsLand,
                 kanIkkeOppgiPersonident = it.kanIkkeOppgiPersonident,
             )

--- a/src/main/kotlin/no/nav/familie/ef/søknad/utils/FeltMapperUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/utils/FeltMapperUtil.kt
@@ -28,6 +28,15 @@ fun TekstFelt.tilSøknadsfelt(): Søknadsfelt<String> = Søknadsfelt(label = thi
 
 fun <T> TekstFelt.tilSøknadsfelt(t: (String) -> T): Søknadsfelt<T> = Søknadsfelt(label = this.label, verdi = t.invoke(this.verdi))
 
+fun TekstFelt.tilSøknadsfeltEllerNull(): Søknadsfelt<String>? {
+    return if (this.verdi.isNotBlank()) {
+        Søknadsfelt(label = this.label, verdi = this.verdi, svarId = this.svarid)
+    }
+    else {
+        null
+    }
+}
+
 fun Søknadsfelt<Fødselsnummer>?.fødselsnummerTilTekstFelt(): TekstFelt? =
     this?.let {
         TekstFelt(it.label, it.verdi.verdi, it.svarId?.verdi)


### PR DESCRIPTION
Tidligere sendte mapperen med blanke ("") labels og verdier til mottak i stedet for null dersom utenlandsoppholdet var utenfor eøs. Dette gjorde at de tomme verdiene ble med, og tulla med pdf-kvitteringen