### PR TITLE
📌 Endring: Skjuler overskrift hvis alle verdier er tomme

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadKvitteringController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadKvitteringController.kt
@@ -23,7 +23,6 @@ import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime
 
 // TODO: Endre endepunkt til /api/soknad etter at de andre søknadscontrollerne er utfaset
-@Profile("!prod")
 @RestController
 @RequestMapping(path = ["/api/soknadskvittering"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"])

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/SivilstandsplanerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/SivilstandsplanerMapper.kt
@@ -6,11 +6,20 @@ import no.nav.familie.ef.søknad.utils.Språktekster.Fremtidsplaner
 import no.nav.familie.ef.søknad.utils.tilSøknadsfelt
 import no.nav.familie.kontrakter.ef.søknad.Sivilstandsplaner
 
-object SivilstandsplanerMapper : Mapper<Bosituasjon, Sivilstandsplaner>(Fremtidsplaner) {
-    override fun mapDto(data: Bosituasjon): Sivilstandsplaner =
-        Sivilstandsplaner(
-            harPlaner = data.skalGifteSegEllerBliSamboer?.tilSøknadsfelt(),
-            fraDato = data.datoSkalGifteSegEllerBliSamboer?.tilSøknadsfelt(),
-            vordendeSamboerEktefelle = data.vordendeSamboerEktefelle?.let(PersonMinimumMapper::map),
-        )
+object SivilstandsplanerMapper : Mapper<Bosituasjon, Sivilstandsplaner?>(Fremtidsplaner) {
+    override fun mapDto(data: Bosituasjon): Sivilstandsplaner? {
+        val harPlaner = data.skalGifteSegEllerBliSamboer?.tilSøknadsfelt()
+        val fraDato = data.datoSkalGifteSegEllerBliSamboer?.tilSøknadsfelt()
+        val vordendeSamboerEktefelle = data.vordendeSamboerEktefelle?.let(PersonMinimumMapper::map)
+
+        return if (harPlaner == null && fraDato == null && vordendeSamboerEktefelle == null) {
+            null
+        } else {
+            Sivilstandsplaner(
+                harPlaner = harPlaner,
+                fraDato = fraDato,
+                vordendeSamboerEktefelle = vordendeSamboerEktefelle
+            )
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/familie/ef/søknad/søknad/mapper/SivilstandsplanerMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/søknad/mapper/SivilstandsplanerMapperTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.søknad.søknad.mapper
 
 import no.nav.familie.ef.søknad.mock.søknadDto
 import no.nav.familie.ef.søknad.søknad.domain.Bosituasjon
+import no.nav.familie.ef.søknad.søknad.domain.TekstFelt
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -18,15 +19,16 @@ internal class SivilstandsplanerMapperTest {
         // When
         val sivilstandsplaner = SivilstandsplanerMapper.map(bosituasjonUtenGifteplaner).verdi
         // Then
-        assertThat(sivilstandsplaner.harPlaner?.verdi).isEqualTo(false)
+        assertThat(sivilstandsplaner?.harPlaner?.verdi).isEqualTo(false)
     }
+
 
     @Test
     fun `Vi mapper sivilstandsplaner til verdi true`() {
         // When
         val sivilstandsplaner = SivilstandsplanerMapper.map(bosituasjonGifteplaner).verdi
         // Then
-        assertThat(sivilstandsplaner.harPlaner?.verdi).isEqualTo(true)
+        assertThat(sivilstandsplaner?.harPlaner?.verdi).isEqualTo(true)
     }
 
     @Test
@@ -34,7 +36,7 @@ internal class SivilstandsplanerMapperTest {
         // When
         val sivilstandsplaner = SivilstandsplanerMapper.map(bosituasjonGifteplaner).verdi
         // Then
-        assertThat(sivilstandsplaner.harPlaner?.label).isEqualTo("Har du konkrete planer om å gifte deg eller bli samboer?")
+        assertThat(sivilstandsplaner?.harPlaner?.label).isEqualTo("Har du konkrete planer om å gifte deg eller bli samboer?")
     }
 
     @Test
@@ -42,7 +44,7 @@ internal class SivilstandsplanerMapperTest {
         // When
         val sivilstandsplaner = SivilstandsplanerMapper.map(bosituasjonGifteplaner).verdi
         // Then
-        assertThat(sivilstandsplaner.fraDato?.verdi).isEqualTo(LocalDate.of(2020, 3, 26))
+        assertThat(sivilstandsplaner?.fraDato?.verdi).isEqualTo(LocalDate.of(2020, 3, 26))
     }
 
     @Test
@@ -50,7 +52,7 @@ internal class SivilstandsplanerMapperTest {
         // When
         val sivilstandsplaner = SivilstandsplanerMapper.map(bosituasjonGifteplaner).verdi
         // Then
-        assertThat(sivilstandsplaner.fraDato?.label).isEqualTo("Når skal dette skje?")
+        assertThat(sivilstandsplaner?.fraDato?.label).isEqualTo("Når skal dette skje?")
     }
 
     private fun getBosituasjon(fileName: String) =


### PR DESCRIPTION
✨ Hva er gjort?

Oppdatert SivilstandsplanerMapper slik at den returnerer null hvis alle feltene er tomme.
Sikret at overskriften "Fremtidsplaner" kun vises dersom det faktisk finnes innhold.

🎯 Hvorfor?
Tidligere ble overskriften vist selv om det ikke var noen data, noe som førte til unødvendig visning av tomme seksjoner. Denne endringen forbedrer brukeropplevelsen ved å kun vise overskriften når det er relevant informasjon.