### PR TITLE
Feature - hent ferskeste søknader per stønad når bruker starter søknadflyten

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/config/MottakConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/config/MottakConfig.kt
@@ -24,6 +24,8 @@ data class MottakConfig(
     internal val hentForrigeBarnetilsynSøknadUriKvittering = byggUri(PATH_HENT_FORRIGE_BARNETILSYNSØKNAD_KVITTERING)
     internal val hentSøknadKvitteringUri = byggUri(PATH_HENT_SOKNADKVITTERING)
 
+    internal val hentAktiveSøknaderUri = byggUri(PATH_HENT_AKTIVE_SØKNADER)
+
     internal val pingUri = byggUri(PATH_PING)
 
     private fun byggUri(path: String) =
@@ -49,5 +51,6 @@ data class MottakConfig(
         private const val PATH_HENT_FORRIGE_BARNETILSYNSØKNAD_KVITTERING = "/soknadkvittering/barnetilsyn/forrige"
         private const val PATH_PING = "/ping"
         private const val PATH_HENT_SOKNADKVITTERING = "/soknadskvittering"
+        private const val PATH_HENT_AKTIVE_SØKNADER = "/soknad/aktive"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/config/MottakConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/config/MottakConfig.kt
@@ -24,7 +24,7 @@ data class MottakConfig(
     internal val hentForrigeBarnetilsynSøknadUriKvittering = byggUri(PATH_HENT_FORRIGE_BARNETILSYNSØKNAD_KVITTERING)
     internal val hentSøknadKvitteringUri = byggUri(PATH_HENT_SOKNADKVITTERING)
 
-    internal val hentAktiveSøknaderUri = byggUri(PATH_HENT_AKTIVE_SØKNADER)
+    internal val hentSistInnsendteSøknadPerStønad = byggUri(PATH_HENT_SIST_INNSENDTE_SØKNAD_PER_STØNAD)
 
     internal val pingUri = byggUri(PATH_PING)
 
@@ -51,6 +51,6 @@ data class MottakConfig(
         private const val PATH_HENT_FORRIGE_BARNETILSYNSØKNAD_KVITTERING = "/soknadkvittering/barnetilsyn/forrige"
         private const val PATH_PING = "/ping"
         private const val PATH_HENT_SOKNADKVITTERING = "/soknadskvittering"
-        private const val PATH_HENT_AKTIVE_SØKNADER = "/soknad/aktive"
+        private const val PATH_HENT_SIST_INNSENDTE_SØKNAD_PER_STØNAD = "/soknad/sist-innsendt-per-stonad"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -19,6 +19,7 @@ class FeatureToggleController(
             "familie.ef.soknad.feilsituasjon",
             "familie.ef.soknad.nynorsk",
             "familie.ef.soknad-ny-pdfkvittering",
+            "familie.ef.soknad.frontend.hent-sist-innsendte-soknad-per-stonad"
         )
 
     @GetMapping

--- a/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -19,7 +19,7 @@ class FeatureToggleController(
             "familie.ef.soknad.feilsituasjon",
             "familie.ef.soknad.nynorsk",
             "familie.ef.soknad-ny-pdfkvittering",
-            "familie.ef.soknad.frontend.hent-sist-innsendte-soknad-per-stonad"
+            "familie.ef.soknad.frontend.hent-sist-innsendte-soknad-per-stonad",
         )
 
     @GetMapping

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/MottakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/MottakClient.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.søknad.søknad
 
 import no.nav.familie.ef.søknad.infrastruktur.config.MottakConfig
 import no.nav.familie.ef.søknad.søknad.SøknadClientUtil.filtrerVekkEldreDokumentasjonsbehov
+import no.nav.familie.ef.søknad.søknad.SøknadService.GjeldeneSøknad
 import no.nav.familie.ef.søknad.søknad.dto.KvitteringDto
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.kontrakter.ef.ettersending.EttersendelseDto
@@ -72,6 +73,12 @@ class MottakClient(
     fun hentForrigeBarnetilsynSøknadKvittering(): SøknadBarnetilsyn? =
         getForEntity(
             config.hentForrigeBarnetilsynSøknadUriKvittering,
+            HttpHeaders().medContentTypeJsonUTF8(),
+        )
+
+    fun hentAktiveSøknader(): List<GjeldeneSøknad> =
+        getForEntity(
+            config.hentAktiveSøknaderUri,
             HttpHeaders().medContentTypeJsonUTF8(),
         )
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/MottakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/MottakClient.kt
@@ -2,8 +2,8 @@ package no.nav.familie.ef.søknad.søknad
 
 import no.nav.familie.ef.søknad.infrastruktur.config.MottakConfig
 import no.nav.familie.ef.søknad.søknad.SøknadClientUtil.filtrerVekkEldreDokumentasjonsbehov
-import no.nav.familie.ef.søknad.søknad.SøknadService.GjeldeneSøknad
 import no.nav.familie.ef.søknad.søknad.dto.KvitteringDto
+import no.nav.familie.ef.søknad.søknad.dto.SistInnsendteSøknadDto
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.kontrakter.ef.ettersending.EttersendelseDto
 import no.nav.familie.kontrakter.ef.ettersending.SøknadMedDokumentasjonsbehovDto
@@ -76,9 +76,9 @@ class MottakClient(
             HttpHeaders().medContentTypeJsonUTF8(),
         )
 
-    fun hentAktiveSøknader(): List<GjeldeneSøknad> =
+    fun hentSistInnsendteSøknadPerStønad(): List<SistInnsendteSøknadDto> =
         getForEntity(
-            config.hentAktiveSøknaderUri,
+            config.hentSistInnsendteSøknadPerStønad,
             HttpHeaders().medContentTypeJsonUTF8(),
         )
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadKvitteringController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadKvitteringController.kt
@@ -31,8 +31,12 @@ class SøknadKvitteringController(
     val søknadService: SøknadService,
     private val oppslagService: OppslagService,
 ) {
+    // TODO: Jeg skal ikke bo her, flytt meg senere. Kun for testing.
+    @GetMapping("aktiv")
+    fun hentAktiveSøknader() = søknadService.hentAktiveSøknader()
+
     @PostMapping("overgangsstonad")
-    fun sendInn(
+    private fun sendInn(
         @RequestBody søknad: SøknadOvergangsstønadDto,
     ): Kvittering {
         if (!EksternBrukerUtils.personIdentErLikInnloggetBruker(søknad.person.søker.fnr)) {

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadKvitteringController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadKvitteringController.kt
@@ -32,7 +32,7 @@ class SøknadKvitteringController(
     private val oppslagService: OppslagService,
 ) {
     @PostMapping("overgangsstonad")
-    private fun sendInn(
+    fun sendInn(
         @RequestBody søknad: SøknadOvergangsstønadDto,
     ): Kvittering {
         if (!EksternBrukerUtils.personIdentErLikInnloggetBruker(søknad.person.søker.fnr)) {

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadKvitteringController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadKvitteringController.kt
@@ -31,10 +31,6 @@ class SøknadKvitteringController(
     val søknadService: SøknadService,
     private val oppslagService: OppslagService,
 ) {
-    // TODO: Jeg skal ikke bo her, flytt meg senere. Kun for testing.
-    @GetMapping("aktiv")
-    fun hentAktiveSøknader() = søknadService.hentAktiveSøknader()
-
     @PostMapping("overgangsstonad")
     private fun sendInn(
         @RequestBody søknad: SøknadOvergangsstønadDto,
@@ -85,6 +81,9 @@ class SøknadKvitteringController(
         søknadService.sendInnSøknadskvitteringArbeidssøker(arbeidssøker, fnrFraToken, forkortetNavn, innsendingMottatt)
         return Kvittering("ok", mottattDato = innsendingMottatt)
     }
+
+    @GetMapping("/soknad/sist-innsendt-per-stonad")
+    fun hentSistInnsendteSøknadPerStønad() = søknadService.hentSistInnsendteSøknadPerStønad()
 
     @Profile("!prod")
     @GetMapping("{søknadId}")

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.søknad.søknad
 
 import no.nav.familie.ef.søknad.søknad.domain.Arbeidssøker
 import no.nav.familie.ef.søknad.søknad.domain.Kvittering
+import no.nav.familie.ef.søknad.søknad.dto.SistInnsendteSøknadDto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynDto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynGjenbrukDto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadOvergangsstønadDto
@@ -12,7 +13,6 @@ import no.nav.familie.ef.søknad.søknad.mapper.SøknadBarnetilsynMapper
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadOvergangsstønadMapper
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadSkolepengerMapper
 import org.springframework.stereotype.Service
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Service
@@ -93,12 +93,5 @@ class SøknadService(
 
     fun hentForrigeBarnetilsynSøknadKvittering(): SøknadBarnetilsynGjenbrukDto? = SøknadBarnetilsynMapper().mapTilDto(mottakClient.hentForrigeBarnetilsynSøknadKvittering())
 
-    // TODO: Gå gjennom metodenavn og spesifier opprinnelse
-    fun hentAktiveSøknader(): List<GjeldeneSøknad> = mottakClient.hentAktiveSøknader()
-
-    // TODO: Flytt meg og endre meg som du vil
-    data class GjeldeneSøknad(
-        val søknadsdato: LocalDate?,
-        val søknadType: String?,
-    )
+    fun hentSistInnsendteSøknadPerStønad(): List<SistInnsendteSøknadDto> = mottakClient.hentSistInnsendteSøknadPerStønad()
 }

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadService.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ef.søknad.søknad.mapper.SøknadBarnetilsynMapper
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadOvergangsstønadMapper
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadSkolepengerMapper
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Service
@@ -91,4 +92,13 @@ class SøknadService(
     fun hentForrigeBarnetilsynSøknad(): SøknadBarnetilsynGjenbrukDto? = SøknadBarnetilsynMapper().mapTilDto(mottakClient.hentForrigeBarnetilsynSøknad())
 
     fun hentForrigeBarnetilsynSøknadKvittering(): SøknadBarnetilsynGjenbrukDto? = SøknadBarnetilsynMapper().mapTilDto(mottakClient.hentForrigeBarnetilsynSøknadKvittering())
+
+    // TODO: Gå gjennom metodenavn og spesifier opprinnelse
+    fun hentAktiveSøknader(): List<GjeldeneSøknad> = mottakClient.hentAktiveSøknader()
+
+    // TODO: Flytt meg og endre meg som du vil
+    data class GjeldeneSøknad(
+        val søknadsdato: LocalDate?,
+        val søknadType: String?,
+    )
 }

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/dto/SistInnsendteSøknadDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/dto/SistInnsendteSøknadDto.kt
@@ -1,0 +1,8 @@
+package no.nav.familie.ef.søknad.søknad.dto
+
+import java.time.LocalDate
+
+data class SistInnsendteSøknadDto(
+    val søknadsdato: LocalDate,
+    val søknadType: String,
+)


### PR DESCRIPTION
# Hent ferskeste søknader per stønad når bruker starter søknadflyten

### Hvorfor er denne endringen nødvendig? ✨ 

Vi ønsker å vite om bruker har sendt inn en søknad når bruker starter søknadsflyten. Dette gjør vi i håp om å informere bruker om at det allerede finnes en søknad, noe som kanskje stopper bruker fra å sende en ny, men ellers lik søknad. Det skal fortsatt være mulig å sende en til søknad, men håpet er å redusere søknader som er like. 

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-23469).

Denne PRen er en del av en bredere oppgave og depender på denne → [PRen i familie-ef-mottak](https://github.com/navikt/familie-ef-mottak/pull/1229).

### Verdt å nevne

* Vi planlegger å feature toggle i front-end der vi enkelt ikke gjør kallet med mindre feature toggle er skrudd på.
* Vi har ikke utbedret tekster eller hva som skal skje i front-end. Dette er en litt sporadisk prosess. 