### PR TITLE
Feature - SistInnsendtSøknadDto hentes fra kontrakter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <token-validation-spring.version>5.0.10</token-validation-spring.version>
         <okhttp3.version>4.9.1</okhttp3.version> <!-- overskriver spring sin versjon, blir brukt av mock-oauth2-server -->
         <felles.version>3.20241127123724_adfc561</felles.version>
-        <kontrakter.version>3.0_20250115093204_cbb7a39</kontrakter.version>
+        <kontrakter.version>3.0_20250206092356_0b11dc0</kontrakter.version>
         <start-class>no.nav.familie.ef.søknad.ApplicationKt</start-class>
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>

--- a/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/config/MottakConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/config/MottakConfig.kt
@@ -24,7 +24,7 @@ data class MottakConfig(
     internal val hentForrigeBarnetilsynSøknadUriKvittering = byggUri(PATH_HENT_FORRIGE_BARNETILSYNSØKNAD_KVITTERING)
     internal val hentSøknadKvitteringUri = byggUri(PATH_HENT_SOKNADKVITTERING)
 
-    internal val hentSistInnsendteSøknadPerStønad = byggUri(PATH_HENT_SIST_INNSENDTE_SØKNAD_PER_STØNAD)
+    internal val hentSistInnsendtSøknadPerStønad = byggUri(PATH_HENT_SIST_INNSENDT_SØKNAD_PER_STØNAD)
 
     internal val pingUri = byggUri(PATH_PING)
 
@@ -51,6 +51,6 @@ data class MottakConfig(
         private const val PATH_HENT_FORRIGE_BARNETILSYNSØKNAD_KVITTERING = "/soknadkvittering/barnetilsyn/forrige"
         private const val PATH_PING = "/ping"
         private const val PATH_HENT_SOKNADKVITTERING = "/soknadskvittering"
-        private const val PATH_HENT_SIST_INNSENDTE_SØKNAD_PER_STØNAD = "/soknad/sist-innsendt-per-stonad"
+        private const val PATH_HENT_SIST_INNSENDT_SØKNAD_PER_STØNAD = "/soknad/sist-innsendt-per-stonad"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/MottakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/MottakClient.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ef.søknad.søknad
 import no.nav.familie.ef.søknad.infrastruktur.config.MottakConfig
 import no.nav.familie.ef.søknad.søknad.SøknadClientUtil.filtrerVekkEldreDokumentasjonsbehov
 import no.nav.familie.ef.søknad.søknad.dto.KvitteringDto
-import no.nav.familie.ef.søknad.søknad.dto.SistInnsendteSøknadDto
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.kontrakter.ef.ettersending.EttersendelseDto
 import no.nav.familie.kontrakter.ef.ettersending.SøknadMedDokumentasjonsbehovDto
@@ -15,6 +14,7 @@ import no.nav.familie.kontrakter.ef.søknad.SøknadSkolepenger
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.ef.StønadType
+import no.nav.familie.kontrakter.felles.søknad.SistInnsendtSøknadDto
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpHeaders
 import org.springframework.stereotype.Service
@@ -76,9 +76,9 @@ class MottakClient(
             HttpHeaders().medContentTypeJsonUTF8(),
         )
 
-    fun hentSistInnsendteSøknadPerStønad(): List<SistInnsendteSøknadDto> =
+    fun hentSistInnsendtSøknadPerStønad(): List<SistInnsendtSøknadDto> =
         getForEntity(
-            config.hentSistInnsendteSøknadPerStønad,
+            config.hentSistInnsendtSøknadPerStønad,
             HttpHeaders().medContentTypeJsonUTF8(),
         )
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadKvitteringController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadKvitteringController.kt
@@ -83,7 +83,7 @@ class SøknadKvitteringController(
     }
 
     @GetMapping("sist-innsendt-per-stonad")
-    fun hentSistInnsendteSøknadPerStønad() = søknadService.hentSistInnsendteSøknadPerStønad()
+    fun hentSistInnsendteSøknadPerStønad() = søknadService.hentSistInnsendtSøknadPerStønad()
 
     @Profile("!prod")
     @GetMapping("{søknadId}")

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.søknad.søknad
 
 import no.nav.familie.ef.søknad.søknad.domain.Arbeidssøker
 import no.nav.familie.ef.søknad.søknad.domain.Kvittering
-import no.nav.familie.ef.søknad.søknad.dto.SistInnsendteSøknadDto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynDto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynGjenbrukDto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadOvergangsstønadDto
@@ -12,6 +11,7 @@ import no.nav.familie.ef.søknad.søknad.mapper.SkjemaMapper
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadBarnetilsynMapper
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadOvergangsstønadMapper
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadSkolepengerMapper
+import no.nav.familie.kontrakter.felles.søknad.SistInnsendtSøknadDto
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 
@@ -93,5 +93,5 @@ class SøknadService(
 
     fun hentForrigeBarnetilsynSøknadKvittering(): SøknadBarnetilsynGjenbrukDto? = SøknadBarnetilsynMapper().mapTilDto(mottakClient.hentForrigeBarnetilsynSøknadKvittering())
 
-    fun hentSistInnsendteSøknadPerStønad(): List<SistInnsendteSøknadDto> = mottakClient.hentSistInnsendteSøknadPerStønad()
+    fun hentSistInnsendtSøknadPerStønad(): List<SistInnsendtSøknadDto> = mottakClient.hentSistInnsendtSøknadPerStønad()
 }

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/dto/SistInnsendteSøknadDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/dto/SistInnsendteSøknadDto.kt
@@ -1,8 +1,0 @@
-package no.nav.familie.ef.søknad.søknad.dto
-
-import java.time.LocalDate
-
-data class SistInnsendteSøknadDto(
-    val søknadsdato: LocalDate,
-    val søknadType: String,
-)


### PR DESCRIPTION
# SistInnsendtSøknadDto hentes fra kontrakter

### Hvorfor er denne endringen nødvendig? ✨ 

Denne PRen har som hensikt å hente ut `SistInnsendtSøknadDto` fra `ef-kontrakter` da dette objektet brukes nå av flere apper. Vi har også mappet om typen i `SistInnsendtSøknadDto` fra `String` til `StønadType` i håp om at det skal bli tydeligere i front end.

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-23469).

Denne PRen er en del av en bredre oppgave og depender på denne → [PRen](https://github.com/navikt/familie-ef-mottak/pull/1232) i `familie-ef-mottak`.

### Verdt å nevne

Denne featuren er feature-togglet i front-end.