### PR TITLE
SøknadsPDF - Vise kun gjeldende statsborgerskap

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/person/dto/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/person/dto/PdlPerson.kt
@@ -176,11 +176,11 @@ data class Statsborgerskap(
     val land: String,
     val gyldigFraOgMed: LocalDate?,
     val gyldigTilOgMed: LocalDate?,
-    val metadata: Historisk,
+    val metadata: Historisk?,
 )
 
 data class Historisk(
-    val historisk: Boolean,
+    val historisk: Boolean?,
 )
 
 data class Sivilstand(

--- a/src/main/kotlin/no/nav/familie/ef/søknad/person/dto/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/person/dto/PdlPerson.kt
@@ -176,6 +176,11 @@ data class Statsborgerskap(
     val land: String,
     val gyldigFraOgMed: LocalDate?,
     val gyldigTilOgMed: LocalDate?,
+    val metadata: Historisk,
+)
+
+data class Historisk(
+    val historisk: Boolean,
 )
 
 data class Sivilstand(

--- a/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
@@ -159,7 +159,7 @@ internal class SøkerinfoMapper(
                 poststed = hentPoststed(bostedsadresse.firstOrNull()?.vegadresse?.postnummer),
                 postnummer = bostedsadresse.firstOrNull()?.vegadresse?.postnummer ?: " ",
             )
-        statsborgerskap.forEach {logger.info("Statsborgerskap TEST:" + it.metadata?.historisk.toString() + it.land)}
+        statsborgerskap.forEach { logger.info("Statsborgerskap TEST:" + it.metadata?.historisk.toString() + it.land) }
 
         val statsborgerskapListe = statsborgerskap.map { hentLand(it.land) }.joinToString(", ")
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
@@ -161,7 +161,12 @@ internal class SøkerinfoMapper(
             )
         statsborgerskap.forEach { logger.info("Statsborgerskap TEST:" + it.metadata?.historisk.toString() + it.land) }
 
-        val statsborgerskapListe = statsborgerskap.map { hentLand(it.land) }.joinToString(", ")
+        val statsborgerskapListe =
+            statsborgerskap
+                .filter { it.metadata?.historisk == false }
+                .joinToString(", ") { it.land }
+
+        logger.info("Statsborger full string: $statsborgerskapListe")
 
         val sivilstand: Sivilstand = sivilstand.firstOrNull() ?: Sivilstand(type = Sivilstandstype.UOPPGITT)
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
@@ -162,7 +162,7 @@ internal class SøkerinfoMapper(
 
         val statsborgerskapListe =
             statsborgerskap
-                .filter { it.gyldigTilOgMed?.isAfter(LocalDate.now()) == true || it.gyldigTilOgMed == null}
+                .filter { it.gyldigTilOgMed?.isAfter(LocalDate.now()) == true || it.gyldigTilOgMed == null }
                 .joinToString(", ") { hentLand(it.land) }
 
         val sivilstand: Sivilstand = sivilstand.firstOrNull() ?: Sivilstand(type = Sivilstandstype.UOPPGITT)

--- a/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
@@ -160,9 +160,7 @@ internal class SøkerinfoMapper(
                 postnummer = bostedsadresse.firstOrNull()?.vegadresse?.postnummer ?: " ",
             )
 
-        val statsborgerskapListe =
-            statsborgerskap
-                .joinToString(", ") { hentLand(it.land) }
+        val statsborgerskapListe = statsborgerskap.map { hentLand(it.land) }.joinToString(", ")
 
         val sivilstand: Sivilstand = sivilstand.firstOrNull() ?: Sivilstand(type = Sivilstandstype.UOPPGITT)
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
@@ -162,7 +162,6 @@ internal class SøkerinfoMapper(
 
         val statsborgerskapListe =
             statsborgerskap
-                .filter { it.gyldigTilOgMed?.isAfter(LocalDate.now()) == true || it.gyldigTilOgMed == null }
                 .joinToString(", ") { hentLand(it.land) }
 
         val sivilstand: Sivilstand = sivilstand.firstOrNull() ?: Sivilstand(type = Sivilstandstype.UOPPGITT)

--- a/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
@@ -159,7 +159,7 @@ internal class SøkerinfoMapper(
                 poststed = hentPoststed(bostedsadresse.firstOrNull()?.vegadresse?.postnummer),
                 postnummer = bostedsadresse.firstOrNull()?.vegadresse?.postnummer ?: " ",
             )
-        statsborgerskap.forEach {logger.info("Statsborgerskap TEST:" + it.metadata.historisk.toString() + it.land)}
+        statsborgerskap.forEach {logger.info("Statsborgerskap TEST:" + it.metadata?.historisk.toString() + it.land)}
 
         val statsborgerskapListe = statsborgerskap.map { hentLand(it.land) }.joinToString(", ")
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
@@ -164,7 +164,7 @@ internal class SøkerinfoMapper(
         val statsborgerskapListe =
             statsborgerskap
                 .filter { it.metadata?.historisk == false }
-                .joinToString(", ") { it.land }
+                .joinToString(", ") { hentLand(it.land) }
 
         logger.info("Statsborger full string: $statsborgerskapListe")
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
@@ -159,6 +159,7 @@ internal class SøkerinfoMapper(
                 poststed = hentPoststed(bostedsadresse.firstOrNull()?.vegadresse?.postnummer),
                 postnummer = bostedsadresse.firstOrNull()?.vegadresse?.postnummer ?: " ",
             )
+        statsborgerskap.forEach {logger.info("Statsborgerskap TEST:" + it.metadata.historisk.toString() + it.land)}
 
         val statsborgerskapListe = statsborgerskap.map { hentLand(it.land) }.joinToString(", ")
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
@@ -162,7 +162,7 @@ internal class SøkerinfoMapper(
 
         val statsborgerskapListe =
             statsborgerskap
-                .filter { it.gyldigTilOgMed?.isAfter(LocalDate.now()) == true}
+                .filter { it.gyldigTilOgMed?.isAfter(LocalDate.now()) == true || it.gyldigTilOgMed == null}
                 .joinToString(", ") { hentLand(it.land) }
 
         val sivilstand: Sivilstand = sivilstand.firstOrNull() ?: Sivilstand(type = Sivilstandstype.UOPPGITT)

--- a/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
@@ -162,7 +162,7 @@ internal class SøkerinfoMapper(
 
         val statsborgerskapListe =
             statsborgerskap
-                .filter { it.gyldigTilOgMed?.isAfter(LocalDate.now()) == false }
+                .filter { it.gyldigTilOgMed?.isBefore(LocalDate.now()) == false }
                 .joinToString(", ") { hentLand(it.land) }
 
         val sivilstand: Sivilstand = sivilstand.firstOrNull() ?: Sivilstand(type = Sivilstandstype.UOPPGITT)

--- a/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapper.kt
@@ -162,7 +162,7 @@ internal class SøkerinfoMapper(
 
         val statsborgerskapListe =
             statsborgerskap
-                .filter { it.gyldigTilOgMed?.isBefore(LocalDate.now()) == false }
+                .filter { it.gyldigTilOgMed?.isAfter(LocalDate.now()) == true}
                 .joinToString(", ") { hentLand(it.land) }
 
         val sivilstand: Sivilstand = sivilstand.firstOrNull() ?: Sivilstand(type = Sivilstandstype.UOPPGITT)

--- a/src/main/resources/pdl/søker.graphql
+++ b/src/main/resources/pdl/søker.graphql
@@ -38,9 +38,6 @@ query($ident: ID!){
             land
             gyldigFraOgMed
             gyldigTilOgMed
-            metadata{
-                historisk
-            }
         }
     }
 }

--- a/src/main/resources/pdl/søker.graphql
+++ b/src/main/resources/pdl/søker.graphql
@@ -38,6 +38,9 @@ query($ident: ID!){
             land
             gyldigFraOgMed
             gyldigTilOgMed
+            metadata{
+                historisk
+            }
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/søknad/person/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/person/PdlClientConfig.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.søknad.person.dto.Bostedsadresse
 import no.nav.familie.ef.søknad.person.dto.Familierelasjonsrolle
 import no.nav.familie.ef.søknad.person.dto.ForelderBarnRelasjon
 import no.nav.familie.ef.søknad.person.dto.Fødselsdato
+import no.nav.familie.ef.søknad.person.dto.Historisk
 import no.nav.familie.ef.søknad.person.dto.Navn
 import no.nav.familie.ef.søknad.person.dto.PdlSøker
 import no.nav.familie.ef.søknad.person.dto.Sivilstand
@@ -71,11 +72,13 @@ class PdlClientConfig {
                 land = "NOR",
                 gyldigFraOgMed = startdato,
                 gyldigTilOgMed = null,
+                metadata = Historisk(false),
             ),
             Statsborgerskap(
                 land = "SWE",
                 gyldigFraOgMed = startdato.minusYears(3),
                 gyldigTilOgMed = startdato,
+                metadata = Historisk(false),
             ),
         )
 

--- a/src/test/kotlin/no/nav/familie/ef/søknad/person/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/person/PdlTestdata.kt
@@ -61,7 +61,7 @@ object PdlTestdata {
     private val forelderBarnRelasjon = listOf(ForelderBarnRelasjon("", BARN))
     private val barnsRelasjoner = listOf(ForelderBarnRelasjon("", FAR))
 
-    private val statsborgerskap = listOf(Statsborgerskap("", LocalDate.now(), LocalDate.now(),metadata = Historisk(false),))
+    private val statsborgerskap = listOf(Statsborgerskap("", LocalDate.now(), LocalDate.now(), metadata = Historisk(false)))
 
     val pdlSøkerData =
         PdlSøkerData(

--- a/src/test/kotlin/no/nav/familie/ef/søknad/person/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/person/PdlTestdata.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ef.søknad.person.dto.Familierelasjonsrolle.BARN
 import no.nav.familie.ef.søknad.person.dto.Familierelasjonsrolle.FAR
 import no.nav.familie.ef.søknad.person.dto.ForelderBarnRelasjon
 import no.nav.familie.ef.søknad.person.dto.Fødselsdato
+import no.nav.familie.ef.søknad.person.dto.Historisk
 import no.nav.familie.ef.søknad.person.dto.Matrikkeladresse
 import no.nav.familie.ef.søknad.person.dto.MatrikkeladresseBarn
 import no.nav.familie.ef.søknad.person.dto.Navn
@@ -60,7 +61,7 @@ object PdlTestdata {
     private val forelderBarnRelasjon = listOf(ForelderBarnRelasjon("", BARN))
     private val barnsRelasjoner = listOf(ForelderBarnRelasjon("", FAR))
 
-    private val statsborgerskap = listOf(Statsborgerskap("", LocalDate.now(), LocalDate.now()))
+    private val statsborgerskap = listOf(Statsborgerskap("", LocalDate.now(), LocalDate.now(),metadata = Historisk(false),))
 
     val pdlSøkerData =
         PdlSøkerData(

--- a/src/test/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapperTest.kt
@@ -25,7 +25,6 @@ import no.nav.familie.ef.søknad.person.dto.PdlBarn
 import no.nav.familie.ef.søknad.person.dto.PdlSøker
 import no.nav.familie.ef.søknad.person.dto.Sivilstand
 import no.nav.familie.ef.søknad.person.dto.Sivilstandstype.UOPPGITT
-import no.nav.familie.ef.søknad.person.dto.Statsborgerskap
 import no.nav.familie.ef.søknad.person.dto.Vegadresse
 import no.nav.familie.ef.søknad.person.dto.visningsnavn
 import no.nav.familie.sikkerhet.EksternBrukerUtils
@@ -353,35 +352,6 @@ internal class SøkerinfoMapperTest {
                 barn(bostedsadresseBarn(matrikkeladresse = matrikkeladresseBarn(null))),
             ),
         ).isFalse
-    }
-
-    @Test
-    fun `Skal filtrere bort utgått statsborgerskap og ikke filtrere hvis null verdi`() {
-        val pdlSøker =
-            PdlSøker(
-                adressebeskyttelse = listOf(),
-                bostedsadresse = listOf(),
-                forelderBarnRelasjon = listOf(),
-                navn = listOf(Navn("fornavn", "mellomnavn", "etternavn")),
-                sivilstand = listOf(),
-                statsborgerskap = listOf(Statsborgerskap("NOR", null, LocalDate.now().minusYears(2))),
-                fødselsdato = lagFødseldato(28),
-            )
-        val pdlSøker2 =
-            PdlSøker(
-                adressebeskyttelse = listOf(),
-                bostedsadresse = listOf(),
-                forelderBarnRelasjon = listOf(),
-                navn = listOf(Navn("fornavn", "mellomnavn", "etternavn")),
-                sivilstand = listOf(),
-                statsborgerskap = listOf(Statsborgerskap("NOR", null, null)),
-                fødselsdato = lagFødseldato(28),
-            )
-        val person = søkerinfoMapper.mapTilSøkerinfo(pdlSøker, mapOf("999" to barn), mapOf())
-        val person2 = søkerinfoMapper.mapTilSøkerinfo(pdlSøker2, mapOf("999" to barn), mapOf())
-
-        assertThat(person.søker.statsborgerskap).isEqualTo("")
-        assertThat(person2.søker.statsborgerskap).isEqualTo("NORGE")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/person/mapper/SøkerinfoMapperTest.kt
@@ -25,6 +25,7 @@ import no.nav.familie.ef.søknad.person.dto.PdlBarn
 import no.nav.familie.ef.søknad.person.dto.PdlSøker
 import no.nav.familie.ef.søknad.person.dto.Sivilstand
 import no.nav.familie.ef.søknad.person.dto.Sivilstandstype.UOPPGITT
+import no.nav.familie.ef.søknad.person.dto.Statsborgerskap
 import no.nav.familie.ef.søknad.person.dto.Vegadresse
 import no.nav.familie.ef.søknad.person.dto.visningsnavn
 import no.nav.familie.sikkerhet.EksternBrukerUtils
@@ -352,6 +353,35 @@ internal class SøkerinfoMapperTest {
                 barn(bostedsadresseBarn(matrikkeladresse = matrikkeladresseBarn(null))),
             ),
         ).isFalse
+    }
+
+    @Test
+    fun `Skal filtrere bort utgått statsborgerskap og ikke filtrere hvis null verdi`() {
+        val pdlSøker =
+            PdlSøker(
+                adressebeskyttelse = listOf(),
+                bostedsadresse = listOf(),
+                forelderBarnRelasjon = listOf(),
+                navn = listOf(Navn("fornavn", "mellomnavn", "etternavn")),
+                sivilstand = listOf(),
+                statsborgerskap = listOf(Statsborgerskap("NOR", null, LocalDate.now().minusYears(2))),
+                fødselsdato = lagFødseldato(28),
+            )
+        val pdlSøker2 =
+            PdlSøker(
+                adressebeskyttelse = listOf(),
+                bostedsadresse = listOf(),
+                forelderBarnRelasjon = listOf(),
+                navn = listOf(Navn("fornavn", "mellomnavn", "etternavn")),
+                sivilstand = listOf(),
+                statsborgerskap = listOf(Statsborgerskap("NOR", null, null)),
+                fødselsdato = lagFødseldato(28),
+            )
+        val person = søkerinfoMapper.mapTilSøkerinfo(pdlSøker, mapOf("999" to barn), mapOf())
+        val person2 = søkerinfoMapper.mapTilSøkerinfo(pdlSøker2, mapOf("999" to barn), mapOf())
+
+        assertThat(person.søker.statsborgerskap).isEqualTo("")
+        assertThat(person2.søker.statsborgerskap).isEqualTo("NORGE")
     }
 
     @Test


### PR DESCRIPTION
# SøknadsPDF - Vise kun gjeldende statsborgerskap

### Hvorfor er denne endringen nødvendig? :sparkles:

Tanken var at kun gjeldende statsborgerskap skulle vises i søknads pdf, ble reagert på dobbelt statsborgerskap hvor ett av statsborgerskapene ikke hadde en start dato. Viser seg at gyldigFraOgMed som hentes fra PDL ikke alltid er tilgjengelig og derfor er ikke nødvendvis dette et tegn på at statsborgerskapet ikke er gyldig. Trengs dermed ikke endringer fra orginalt oppsett. Derimot må det fjernes noen endringer gjort tidligere for testing av dette med logging.

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24389).


