### PR TITLE
Valider svar id til gjenbruk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadController.kt
@@ -81,8 +81,7 @@ class SøknadController(
     @GetMapping("barnetilsyn/forrige")
     fun hentForrigeBarnetilsynSøknad(): SøknadBarnetilsynGjenbrukDto? {
         val søknad = søknadService.hentForrigeBarnetilsynSøknadKvittering()
-        val harGyldigeSvarIds = søknadService.harSøknadGyldigeVerdier(søknad)
-        return if (harGyldigeSvarIds == true) {
+        return if (søknadService.harSøknadGyldigeVerdier(søknad)) {
             søknad
         } else {
             null

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadController.kt
@@ -81,8 +81,12 @@ class SøknadController(
     @GetMapping("barnetilsyn/forrige")
     fun hentForrigeBarnetilsynSøknad(): SøknadBarnetilsynGjenbrukDto? {
         val søknad = søknadService.hentForrigeBarnetilsynSøknadKvittering()
-        søknadService.validerSøknadTilGjenbruk(søknad)
-        return søknad
+        val harGyldigeSvarIds = søknadService.harSøknadGyldigeVerdier(søknad)
+        return if (harGyldigeSvarIds == true) {
+            søknad
+        } else {
+            null
+        }
     }
 
     @GetMapping("sist-innsendt-per-stonad")

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadController.kt
@@ -79,7 +79,11 @@ class SøknadController(
     }
 
     @GetMapping("barnetilsyn/forrige")
-    fun hentForrigeBarnetilsynSøknad(): SøknadBarnetilsynGjenbrukDto? = søknadService.hentForrigeBarnetilsynSøknadKvittering()
+    fun hentForrigeBarnetilsynSøknad(): SøknadBarnetilsynGjenbrukDto? {
+        val søknad = søknadService.hentForrigeBarnetilsynSøknadKvittering()
+        søknadService.validerSøknadTilGjenbruk(søknad)
+        return søknad
+    }
 
     @GetMapping("sist-innsendt-per-stonad")
     fun hentSistInnsendteSøknadPerStønad() = søknadService.hentSistInnsendtSøknadPerStønad()

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadService.kt
@@ -69,8 +69,8 @@ class SøknadService(
 
     fun hentSistInnsendtSøknadPerStønad(): List<SistInnsendtSøknadDto> = mottakClient.hentSistInnsendtSøknadPerStønad()
 
-    fun validerSøknadTilGjenbruk(søknadBarnetilsynGjenbrukDto: SøknadBarnetilsynGjenbrukDto?) {
-        søknadBarnetilsynGjenbrukDto?.let { søknadBT ->
+    fun harSøknadGyldigeVerdier(søknadBarnetilsynGjenbrukDto: SøknadBarnetilsynGjenbrukDto?): Boolean? {
+        return søknadBarnetilsynGjenbrukDto?.let { søknadBT ->
             søknadBT.person.barn
                 .filter { it.forelder != null }
                 .all { barn -> barn.forelder?.harDereSkriftligSamværsavtale?.harGyldigSvarId() ?: true && barn.forelder?.harAnnenForelderSamværMedBarn.harGyldigSvarId() && barn.forelder?.borAnnenForelderISammeHus.harGyldigSvarId() && barn.forelder?.hvorMyeSammen.harGyldigSvarId() }

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadService.kt
@@ -69,7 +69,7 @@ class SøknadService(
 
     fun hentSistInnsendtSøknadPerStønad(): List<SistInnsendtSøknadDto> = mottakClient.hentSistInnsendtSøknadPerStønad()
 
-    fun harSøknadGyldigeVerdier(søknadBarnetilsynGjenbrukDto: SøknadBarnetilsynGjenbrukDto?): Boolean? {
+    fun harSøknadGyldigeVerdier(søknadBarnetilsynGjenbrukDto: SøknadBarnetilsynGjenbrukDto?): Boolean {
         val gyldigeSvarIds =
             søknadBarnetilsynGjenbrukDto?.let { søknadBT ->
                 søknadBT.person.barn
@@ -79,8 +79,10 @@ class SøknadService(
         if (gyldigeSvarIds == false) {
             logger.warn("Fant ugyldige SvarIds for barnetilsyn-søknad. Se securelogs for mer informasjon.")
             logger.warn("Fant ugyldige SvarIds for barnetilsyn-søknad. Gjelder ${søknadBarnetilsynGjenbrukDto.person.barn.map { barn -> barn.forelder }}")
+            return false
+        } else {
+            return true
         }
-        return gyldigeSvarIds
     }
 
     fun TekstFelt?.harGyldigSvarId(): Boolean = this == null || this.svarid == null || SvarId.fromVerdi(this.svarid) != null

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/domain/SvarId.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/domain/SvarId.kt
@@ -1,0 +1,42 @@
+package no.nav.familie.ef.søknad.søknad.domain
+
+enum class SvarId(
+    val verdi: String,
+) {
+    JA("ja"),
+    NEI("nei"),
+
+    // val årsakEnslig: TekstFelt? = null,
+    SAMLIVSBRUDD_FOREDLRE("samlivsbruddForeldre"),
+    SAMLIVSBRUDD_ANDRE("samlivsbruddAndre"),
+    ALENE_FRA_FØDSEL("aleneFraFødsel"),
+    ENDRING_I_SAMVÆRSORDNING("endringISamværsordning"),
+    DØDSFALL("dødsfall"),
+
+    // Skriftlig samværsavtale
+    JA_KONKRETE_TIDSPUNKTER("jaKonkreteTidspunkter"),
+    JA_IKKE_KONKRETE_TIDSPUNKTER("jaIkkeKonkreteTidspunkter"),
+
+    // Kontakt mellom foreldre
+    MØTES_IKKE("møtesIkke"),
+    KUN_NÅR_LEVERES("kunNårLeveres"),
+    MØTES_UTENOM("møtesUtenom"),
+
+    // Medlemskap - Oppholdsland
+
+    // Bosituasjon - delerDuBolig = bosituasjon.delerDuBolig.svarId,
+    BOR_ALENE_MED_BARN_ELLER_GRAVID("borAleneMedBarnEllerGravid"),
+    BOR_MIDLERTIDIG_FRA_HVERANDRE("borMidlertidigFraHverandre"),
+    BOR_SAMMEN_OG_VENTER_BARN("borSammenOgVenterBarn"),
+    HAR_EKTESKAPSLIKNENDE_FORHOLD("harEkteskapsliknendeForhold"),
+    DELER_BOLIG_MED_ANDRE_VOKSNE("delerBoligMedAndreVoksne"),
+    TIDLIGERE_SAMBOER_FORTSATT_REGISTRERT_PÅ_ADRESSE("tidligereSamboerFortsattRegistrertPåAdresse"),
+
+    // Aktivitet
+    // hvordanErArbeidssituasjonen
+    // arbeidsgiver - fastEllerMidlertidig
+    // arbeidsforhold = Arbeidsgiver fast eller midlertidig
+    // under utdanning - offentligEllerPrivat, heltidEllerDeltid
+    PRIVAT("privat"),
+    OFFENTLIG("offentlig"),
+}

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/domain/SvarId.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/domain/SvarId.kt
@@ -39,4 +39,11 @@ enum class SvarId(
     // under utdanning - offentligEllerPrivat, heltidEllerDeltid
     PRIVAT("privat"),
     OFFENTLIG("offentlig"),
+    ;
+
+    companion object {
+        private val map = entries.associateBy { it.verdi }
+
+        fun fromVerdi(verdi: String): SvarId? = map[verdi]
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/domain/SvarIdValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/domain/SvarIdValidator.kt
@@ -1,0 +1,36 @@
+package no.nav.familie.ef.søknad.søknad.domain
+
+import no.nav.familie.kontrakter.ef.iverksett.SvarId
+import org.slf4j.LoggerFactory
+
+// === Mapper fra String til enum SvarId? ===
+fun String?.tilSvarIdOrNull(): SvarId? =
+    try {
+        this?.takeIf { it.isNotBlank() }?.let { enumValueOf<SvarId>(it) }
+    } catch (e: IllegalArgumentException) {
+        null // ugyldig enum-verdi => null
+    }
+
+fun String?.requireSvarId(feltNavn: String): SvarId? =
+    this?.takeIf { it.isNotBlank() }?.let {
+        SvarId.valueOf(it)
+    }
+
+// === Extension-funksjoner for felttyper ===
+
+fun TekstFelt?.tilSvarIdOrNull(): SvarId? = this?.svarid.tilSvarIdOrNull()
+
+fun TekstFelt?.harGyldigSvarId(): Boolean = this?.svarid.kanMappesTilSvarIdEnum(this?.label ?: "ukjent TekstFelt")
+
+fun String?.kanMappesTilSvarIdEnum(feltNavn: String): Boolean {
+    if (this == null) return true
+    try {
+        enumValueOf<SvarId>(this)
+    } catch (e: IllegalArgumentException) {
+        return false
+    }
+
+    return true
+}
+
+fun BooleanFelt?.requireSvarIdIfPresent(): Boolean? = this?.svarid.kanMappesTilSvarIdEnum(this?.label ?: "ukjent BooleanFelt")

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/domain/SvarIdValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/domain/SvarIdValidator.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ef.søknad.søknad.domain
 import no.nav.familie.kontrakter.ef.iverksett.SvarId
 import org.slf4j.LoggerFactory
 
-// === Mapper fra String til enum SvarId? ===
 fun String?.tilSvarIdOrNull(): SvarId? =
     try {
         this?.takeIf { it.isNotBlank() }?.let { enumValueOf<SvarId>(it) }
@@ -11,19 +10,12 @@ fun String?.tilSvarIdOrNull(): SvarId? =
         null // ugyldig enum-verdi => null
     }
 
-fun String?.requireSvarId(feltNavn: String): SvarId? =
-    this?.takeIf { it.isNotBlank() }?.let {
-        SvarId.valueOf(it)
-    }
-
-// === Extension-funksjoner for felttyper ===
-
 fun TekstFelt?.tilSvarIdOrNull(): SvarId? = this?.svarid.tilSvarIdOrNull()
 
-fun TekstFelt?.harGyldigSvarId(): Boolean = this?.svarid.kanMappesTilSvarIdEnum(this?.label ?: "ukjent TekstFelt")
+fun TekstFelt?.harGyldigSvarId(): Boolean? = this?.svarid.kanMappesTilSvarIdEnum()
 
-fun String?.kanMappesTilSvarIdEnum(feltNavn: String): Boolean {
-    if (this == null) return true
+fun String?.kanMappesTilSvarIdEnum(): Boolean? {
+    if (this == null) return null
     try {
         enumValueOf<SvarId>(this)
     } catch (e: IllegalArgumentException) {
@@ -33,4 +25,4 @@ fun String?.kanMappesTilSvarIdEnum(feltNavn: String): Boolean {
     return true
 }
 
-fun BooleanFelt?.requireSvarIdIfPresent(): Boolean? = this?.svarid.kanMappesTilSvarIdEnum(this?.label ?: "ukjent BooleanFelt")
+fun BooleanFelt?.requireSvarIdIfPresent(): Boolean? = this?.svarid.kanMappesTilSvarIdEnum()

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/SøknadSkolepengerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/SøknadSkolepengerMapper.kt
@@ -44,7 +44,7 @@ class SøknadSkolepengerMapper {
                 dokumentasjon =
                     SkolepengerDokumentasjon(
                         utdanningsutgifter = dokumentfelt(DokumentIdentifikator.UTGIFTER_UTDANNING, vedlegg),
-                        utdanningDokumentasjon = dokumentfelt(DokumentIdentifikator.UTDANNING, vedlegg)
+                        utdanningDokumentasjon = dokumentfelt(DokumentIdentifikator.UTDANNING, vedlegg),
                     ),
             )
 

--- a/src/test/kotlin/no/nav/familie/ef/søknad/mock/SøknadDto.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/mock/SøknadDto.kt
@@ -10,7 +10,7 @@ import java.io.File
 
 fun søknadOvergangsstønadDto(): SøknadOvergangsstønadDto = objectMapper.readValue(File("src/test/resources/søknadDto.json"), SøknadOvergangsstønadDto::class.java)
 
-fun søknadBarnetilsynDto(): SøknadBarnetilsynDto = objectMapper.readValue(File("src/test/resources/barnetilsyn/Barnetilsynsøknad.json"), SøknadBarnetilsynDto::class.java)
+fun søknadBarnetilsynDto(): SøknadBarnetilsynDto = objectMapper.readValue(File("src/test/resources/barnetilsyn/BarnetilsynsøknadDto.json"), SøknadBarnetilsynDto::class.java)
 
 fun søknadSkolepengerDto(): SøknadSkolepengerDto = objectMapper.readValue(File("src/test/resources/skolepenger/skolepenger.json"), SøknadSkolepengerDto::class.java)
 

--- a/src/test/kotlin/no/nav/familie/ef/søknad/søknad/SøknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/søknad/SøknadServiceTest.kt
@@ -1,0 +1,42 @@
+package no.nav.familie.ef.søknad.søknad
+
+import io.mockk.mockk
+import no.nav.familie.ef.søknad.søknad.domain.Bosituasjon
+import no.nav.familie.ef.søknad.søknad.domain.Medlemskap
+import no.nav.familie.ef.søknad.søknad.domain.SivilstatusTilGjenbruk
+import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynDto
+import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynGjenbrukDto
+import no.nav.familie.ef.søknad.søknad.mapper.SøknadBarnetilsynMapper
+import no.nav.familie.ef.søknad.søknad.mapper.SøknadOvergangsstønadMapper
+import no.nav.familie.ef.søknad.søknad.mapper.SøknadSkolepengerMapper
+import no.nav.familie.kontrakter.ef.søknad.SøknadBarnetilsyn
+import no.nav.familie.kontrakter.felles.objectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.time.LocalDateTime
+
+class SøknadServiceTest {
+    private val mottakClient = mockk<MottakClient>()
+
+    private val søknadService =
+        SøknadService(
+            mottakClient = mottakClient,
+            overgangsstønadMapper = SøknadOvergangsstønadMapper(),
+            barnetilsynMapper = SøknadBarnetilsynMapper(),
+            skolepengerMapper = SøknadSkolepengerMapper(),
+        )
+
+    @Test
+    fun harSøknadGyldigeVerdier() {
+        val søknadBT =
+            objectMapper.readValue(
+                File("src/test/resources/barnetilsyn/Barnetilsynsøknad.json"),
+                SøknadBarnetilsyn::class.java,
+            )
+
+        val søknadTilGjenbruk = SøknadBarnetilsynMapper().mapTilDto(søknadBT)
+        val skalHaGyldigeVerdier = søknadService.harSøknadGyldigeVerdier(søknadTilGjenbruk)
+        assertThat(skalHaGyldigeVerdier).isTrue
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/søknad/søknad/SøknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/søknad/SøknadServiceTest.kt
@@ -1,15 +1,14 @@
 package no.nav.familie.ef.søknad.søknad
 
 import io.mockk.mockk
-import no.nav.familie.ef.søknad.søknad.domain.Bosituasjon
-import no.nav.familie.ef.søknad.søknad.domain.Medlemskap
-import no.nav.familie.ef.søknad.søknad.domain.SivilstatusTilGjenbruk
-import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynDto
-import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynGjenbrukDto
+import no.nav.familie.ef.søknad.søknad.domain.AnnenForelder
+import no.nav.familie.ef.søknad.søknad.domain.PersonTilGjenbruk
+import no.nav.familie.ef.søknad.søknad.domain.SvarId
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadBarnetilsynMapper
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadOvergangsstønadMapper
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadSkolepengerMapper
 import no.nav.familie.kontrakter.ef.søknad.SøknadBarnetilsyn
+import no.nav.familie.kontrakter.ef.søknad.Søknadsfelt
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -28,7 +27,32 @@ class SøknadServiceTest {
         )
 
     @Test
-    fun harSøknadGyldigeVerdier() {
+    fun `sjekk gyldige svarIds i barnetilsynsøknad - har bare gyldige verdier`() {
+        val søknadBT =
+            objectMapper.readValue(
+                File("src/test/resources/barnetilsyn/Barnetilsynsøknad.json"),
+                SøknadBarnetilsyn::class.java,
+            )
+
+        val søknadTilGjenbruk = SøknadBarnetilsynMapper().mapTilDto(søknadBT)
+        val barn = søknadTilGjenbruk?.person?.barn?.first()
+        val annenForelder = barn?.forelder
+        val borAnnenForelderISammeHusMedGyldigSvarId =
+            søknadTilGjenbruk
+                ?.person
+                ?.barn
+                ?.first()
+                ?.forelder
+                ?.borAnnenForelderISammeHus
+                ?.copy(svarid = SvarId.NEI.verdi)
+        val barnMedGyldigSvarId = barn?.copy(forelder = annenForelder?.copy(borAnnenForelderISammeHus = borAnnenForelderISammeHusMedGyldigSvarId))!!
+        val oppdatertSøknadTilGjenbruk = søknadTilGjenbruk.copy(person = PersonTilGjenbruk(barn = listOf(barnMedGyldigSvarId)))
+        val skalHaGyldigeVerdier = søknadService.harSøknadGyldigeVerdier(oppdatertSøknadTilGjenbruk)
+        assertThat(skalHaGyldigeVerdier).isTrue
+    }
+
+    @Test
+    fun `sjekk gyldige svarIds i barnetilsynsøknad - borISammeHus mangler svarId (og blir mappet til 'null' som string)`() {
         val søknadBT =
             objectMapper.readValue(
                 File("src/test/resources/barnetilsyn/Barnetilsynsøknad.json"),
@@ -37,6 +61,6 @@ class SøknadServiceTest {
 
         val søknadTilGjenbruk = SøknadBarnetilsynMapper().mapTilDto(søknadBT)
         val skalHaGyldigeVerdier = søknadService.harSøknadGyldigeVerdier(søknadTilGjenbruk)
-        assertThat(skalHaGyldigeVerdier).isTrue
+        assertThat(skalHaGyldigeVerdier).isFalse
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/søknad/søknad/domain/SvarIdValidatorTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/søknad/domain/SvarIdValidatorTest.kt
@@ -1,0 +1,34 @@
+package no.nav.familie.ef.søknad.søknad.domain
+
+import no.nav.familie.kontrakter.ef.iverksett.SvarId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SvarIdValidatorTest {
+    @Test
+    fun `requireSvarIdIfPresent for BooleanFelt`() {
+        val booleanFelt = BooleanFelt("Bor du på denne adressen?", true, null)
+        assertThat(booleanFelt.requireSvarIdIfPresent()).isNull()
+
+        val booleanFeltMedSvarId = BooleanFelt("Bor du på denne adressen?", true, SvarId.JA.name)
+        assertThat(booleanFeltMedSvarId.requireSvarIdIfPresent()).isEqualTo(SvarId.JA)
+
+        val booleanFeltMedSvarIdSomIkkeFinnes = BooleanFelt("Bor du på denne adressen?", true, "null")
+        assertThrows<IllegalStateException> {
+            booleanFeltMedSvarIdSomIkkeFinnes.requireSvarIdIfPresent()
+        }
+    }
+
+    @Test
+    fun `requireSvarIdIfPresent for TekstFelt`() {
+        val tekstFelt = TekstFelt("Hvorfor er du alene med barn?", "Samlivsbrudd med den andre forelderen", null)
+        assertThat(tekstFelt.harGyldigSvarId()).isNull()
+
+        val tekstFeltMedSvarId = TekstFelt("Bor du på denne adressen?", "Samlivsbrudd med den andre forelderen", "JA")
+        assertThat(tekstFeltMedSvarId.tilSvarIdOrNull()).isEqualTo(SvarId.JA)
+
+        val tekstFeltMedSvarIdSomIkkeFinnes = TekstFelt("Bor du på denne adressen?", "Samlivsbrudd med den andre forelderen", "null")
+        assertThat(tekstFeltMedSvarIdSomIkkeFinnes).isNull()
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/søknad/søknad/domain/SvarIdValidatorTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/søknad/domain/SvarIdValidatorTest.kt
@@ -12,12 +12,10 @@ class SvarIdValidatorTest {
         assertThat(booleanFelt.requireSvarIdIfPresent()).isNull()
 
         val booleanFeltMedSvarId = BooleanFelt("Bor du på denne adressen?", true, SvarId.JA.name)
-        assertThat(booleanFeltMedSvarId.requireSvarIdIfPresent()).isEqualTo(SvarId.JA)
+        assertThat(booleanFeltMedSvarId.requireSvarIdIfPresent()).isEqualTo(true)
 
         val booleanFeltMedSvarIdSomIkkeFinnes = BooleanFelt("Bor du på denne adressen?", true, "null")
-        assertThrows<IllegalStateException> {
-            booleanFeltMedSvarIdSomIkkeFinnes.requireSvarIdIfPresent()
-        }
+        assertThat(booleanFeltMedSvarIdSomIkkeFinnes.requireSvarIdIfPresent()).isEqualTo(false)
     }
 
     @Test
@@ -29,6 +27,6 @@ class SvarIdValidatorTest {
         assertThat(tekstFeltMedSvarId.tilSvarIdOrNull()).isEqualTo(SvarId.JA)
 
         val tekstFeltMedSvarIdSomIkkeFinnes = TekstFelt("Bor du på denne adressen?", "Samlivsbrudd med den andre forelderen", "null")
-        assertThat(tekstFeltMedSvarIdSomIkkeFinnes).isNull()
+        assertThat(tekstFeltMedSvarIdSomIkkeFinnes.harGyldigSvarId()).isEqualTo(false)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/søknad/søknad/mapper/SøknadBarnetilsynMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/søknad/mapper/SøknadBarnetilsynMapperTest.kt
@@ -24,7 +24,7 @@ internal class SøknadBarnetilsynMapperTest {
 
     private val søknad: SøknadBarnetilsynDto =
         objectMapper.readValue(
-            File("src/test/resources/barnetilsyn/Barnetilsynsøknad.json"),
+            File("src/test/resources/barnetilsyn/BarnetilsynsøknadDto.json"),
             SøknadBarnetilsynDto::class.java,
         )
 

--- a/src/test/resources/barnetilsyn/Barnetilsynsøknad.json
+++ b/src/test/resources/barnetilsyn/Barnetilsynsøknad.json
@@ -1,608 +1,754 @@
 {
-  "person": {
-    "søker": {
-      "fnr": "19128449828",
-      "forkortetNavn": "Kari Nordmann",
-      "adresse": {
-        "adresse": "Jerpefaret 5C",
-        "adressetillegg": "",
-        "kommune": "0104",
-        "postnummer": "1440"
+  "innsendingsdetaljer": {
+    "label": "Innsendingsdetaljer",
+    "verdi": {
+      "datoMottatt": {
+        "label": "Dato mottatt",
+        "verdi": "2025-08-21T12:22:35.515537",
+        "alternativer": null,
+        "svarId": null
       },
-      "egenansatt": false,
-      "innvandretDato": null,
-      "utvandretDato": null,
-      "oppholdstillatelse": null,
-      "sivilstand": "UGIF",
-      "språk": "",
-      "statsborgerskap": "NOR",
-      "privattelefon": null,
-      "mobiltelefon": null,
-      "jobbtelefon": null,
-      "kontakttelefon": "99988877",
-      "bankkontonummer": null
+      "datoPåbegyntSøknad": null,
+      "språk": "nb"
     },
-    "barn": [
-      {
-        "id": "12345",
-        "fnr": "28021078036",
-        "ident": {
-          "label": "Fødselsnummer (11 siffer) / d-nummer",
-          "verdi": "28021078036"
+    "alternativer": null,
+    "svarId": null
+  },
+  "personalia": {
+    "label": "Søker",
+    "verdi": {
+      "fødselsnummer": {
+        "label": "Fødselsnummer",
+        "verdi": {
+          "verdi": "19128449828"
         },
+        "alternativer": null,
+        "svarId": null
+      },
+      "navn": {
+        "label": "Navn",
+        "verdi": "Kari Nordmann",
+        "alternativer": null,
+        "svarId": null
+      },
+      "statsborgerskap": {
+        "label": "Statsborgerskap",
+        "verdi": "NOR",
+        "alternativer": null,
+        "svarId": null
+      },
+      "adresse": {
+        "label": "Adresse",
+        "verdi": {
+          "adresse": "Jerpefaret 5C",
+          "postnummer": "1440",
+          "poststedsnavn": "",
+          "land": ""
+        },
+        "alternativer": null,
+        "svarId": null
+      },
+      "sivilstatus": {
+        "label": "Sivilstatus",
+        "verdi": "UGIF",
+        "alternativer": null,
+        "svarId": null
+      }
+    },
+    "alternativer": null,
+    "svarId": null
+  },
+  "adresseopplysninger": {
+    "label": "Opplysninger om adresse",
+    "verdi": {
+      "søkerBorPåRegistrertAdresse": null,
+      "harMeldtAdresseendring": null,
+      "dokumentasjonAdresseendring": null
+    },
+    "alternativer": null,
+    "svarId": null
+  },
+  "sivilstandsdetaljer": {
+    "label": "Årsak til alene med barn",
+    "verdi": {
+      "erUformeltGift": {
+        "label": "Søker gift i utlandet",
+        "verdi": false,
+        "alternativer": null,
+        "svarId": null
+      },
+      "erUformeltGiftDokumentasjon": {
+        "label": "Dokumentasjon på inngått ekteskap",
+        "verdi": {
+          "harSendtInnTidligere": {
+            "label": "Jeg har sendt inn denne dokumentasjonen til Nav tidligere",
+            "verdi": false,
+            "alternativer": null,
+            "svarId": null
+          },
+          "dokumenter": [
+            {
+              "id": "56ca1b13-9167-4ff4-98a6-f34b8fc8a95d",
+              "navn": "Avtalebetingelser_23.pdf"
+            },
+            {
+              "id": "a60c026a-ac2b-4b70-8cc3-bbe0d8e94e67",
+              "navn": "Avtalebetingelser_23.pdf"
+            },
+            {
+              "id": "9480ca05-f19e-4eb8-9219-d7b7bdc857fd",
+              "navn": "Treningsopplegg09_06_2020.pdf"
+            }
+          ]
+        },
+        "alternativer": null,
+        "svarId": null
+      },
+      "erUformeltSeparertEllerSkilt": {
+        "label": "søker Separert Eller Skilt I Utlandet",
+        "verdi": true,
+        "alternativer": null,
+        "svarId": null
+      },
+      "erUformeltSeparertEllerSkiltDokumentasjon": null,
+      "søktOmSkilsmisseSeparasjon": {
+        "label": "Søker har søkt separasjon",
+        "verdi": false,
+        "alternativer": null,
+        "svarId": null
+      },
+      "datoSøktSeparasjon": {
+        "label": "Dato for samlivsbrudd",
+        "verdi": "2020-01-01",
+        "alternativer": null,
+        "svarId": null
+      },
+      "separasjonsbekreftelse": null,
+      "årsakEnslig": {
+        "label": "årsakEnslig",
+        "verdi": "Jeg trenger hjelp",
+        "alternativer": null,
+        "svarId": null
+      },
+      "samlivsbruddsdokumentasjon": null,
+      "samlivsbruddsdato": {
+        "label": "Dato for samlivsbrudd",
+        "verdi": "2014-10-03",
+        "alternativer": null,
+        "svarId": null
+      },
+      "fraflytningsdato": {
+        "label": "datoFlyttetFraHverandre",
+        "verdi": "2014-10-04",
+        "alternativer": null,
+        "svarId": null
+      },
+      "endringSamværsordningDato": {
+        "label": "datoEndretSamvær",
+        "verdi": "2014-10-05",
+        "alternativer": null,
+        "svarId": null
+      },
+      "tidligereSamboerdetaljer": {
+        "label": "Om den tidligere samboeren din",
+        "verdi": {
+          "navn": {
+            "label": "Navn",
+            "verdi": "Pelle proff",
+            "alternativer": null,
+            "svarId": null
+          },
+          "fødselsnummer": null,
+          "fødselsdato": {
+            "label": "Fødselsdato",
+            "verdi": "2020-06-01",
+            "alternativer": null,
+            "svarId": null
+          },
+          "land": null
+        },
+        "alternativer": null,
+        "svarId": null
+      }
+    },
+    "alternativer": null,
+    "svarId": null
+  },
+  "medlemskapsdetaljer": {
+    "label": "Opphold i Norge",
+    "verdi": {
+      "oppholderDuDegINorge": {
+        "label": "Oppholder du deg i Norge?",
+        "verdi": true,
+        "alternativer": null,
+        "svarId": null
+      },
+      "oppholdsland": null,
+      "bosattNorgeSisteÅrene": {
+        "label": "Har du vært bosatt i Norge de siste tre årene?",
+        "verdi": false,
+        "alternativer": null,
+        "svarId": null
+      },
+      "utenlandsopphold": {
+        "label": "Utenlandsopphold",
+        "verdi": [
+          {
+            "fradato": {
+              "label": "Fra",
+              "verdi": "2019-05-01",
+              "alternativer": null,
+              "svarId": null
+            },
+            "tildato": {
+              "label": "Til",
+              "verdi": "2019-10-01",
+              "alternativer": null,
+              "svarId": null
+            },
+            "land": null,
+            "årsakUtenlandsopphold": {
+              "label": "Hvorfor bodde du i utlandet?",
+              "verdi": "Jobbet litt",
+              "alternativer": null,
+              "svarId": null
+            },
+            "personidentEøsLand": null,
+            "adresseEøsLand": null,
+            "erEøsLand": null,
+            "kanIkkeOppgiPersonident": null
+          },
+          {
+            "fradato": {
+              "label": "Fra",
+              "verdi": "2019-11-27",
+              "alternativer": null,
+              "svarId": null
+            },
+            "tildato": {
+              "label": "Til",
+              "verdi": "2020-02-01",
+              "alternativer": null,
+              "svarId": null
+            },
+            "land": null,
+            "årsakUtenlandsopphold": {
+              "label": "Hvorfor bodde du i utlandet?",
+              "verdi": "Jobbet mer",
+              "alternativer": null,
+              "svarId": null
+            },
+            "personidentEøsLand": null,
+            "adresseEøsLand": null,
+            "erEøsLand": null,
+            "kanIkkeOppgiPersonident": null
+          }
+        ],
+        "alternativer": null,
+        "svarId": null
+      }
+    },
+    "alternativer": null,
+    "svarId": null
+  },
+  "bosituasjon": {
+    "label": "Bosituasjonen din",
+    "verdi": {
+      "delerDuBolig": {
+        "label": "Deler du bolig med andre voksne?",
+        "verdi": "Nei, jeg bor alene med barn eller jeg er gravid og bor alene",
+        "alternativer": null,
+        "svarId": null
+      },
+      "samboerdetaljer": {
+        "label": "Om samboeren din",
+        "verdi": {
+          "navn": {
+            "label": "Navn",
+            "verdi": "Pelle proff",
+            "alternativer": null,
+            "svarId": null
+          },
+          "fødselsnummer": null,
+          "fødselsdato": {
+            "label": "Fødselsdato",
+            "verdi": "2020-06-01",
+            "alternativer": null,
+            "svarId": null
+          },
+          "land": null
+        },
+        "alternativer": null,
+        "svarId": null
+      },
+      "sammenflyttingsdato": {
+        "label": "Label",
+        "verdi": "2020-01-01",
+        "alternativer": null,
+        "svarId": null
+      },
+      "datoFlyttetFraHverandre": {
+        "label": "datoFlyttetFraHverandre",
+        "verdi": "2014-10-04",
+        "alternativer": null,
+        "svarId": null
+      },
+      "tidligereSamboerFortsattRegistrertPåAdresse": {
+        "label": "Bor på ulike adresser",
+        "verdi": {
+          "harSendtInnTidligere": {
+            "label": "Jeg har sendt inn denne dokumentasjonen til Nav tidligere",
+            "verdi": false,
+            "alternativer": null,
+            "svarId": null
+          },
+          "dokumenter": []
+        },
+        "alternativer": null,
+        "svarId": null
+      }
+    },
+    "alternativer": null,
+    "svarId": null
+  },
+  "sivilstandsplaner": {
+    "label": "Fremtidsplaner",
+    "verdi": {
+      "harPlaner": {
+        "label": "Har du konkrete planer om å gifte deg eller bli samboer?",
+        "verdi": false,
+        "alternativer": null,
+        "svarId": null
+      },
+      "fraDato": {
+        "label": "Dato skal gifte seg eller bli samboer",
+        "verdi": "2020-01-01",
+        "alternativer": null,
+        "svarId": null
+      },
+      "vordendeSamboerEktefelle": null
+    },
+    "alternativer": null,
+    "svarId": null
+  },
+  "barn": {
+    "label": "Barna dine",
+    "verdi": [
+      {
         "navn": {
           "label": "Navn",
-          "verdi": "SHIBA INU"
+          "verdi": "SHIBA INU",
+          "alternativer": null,
+          "svarId": null
         },
-        "alder": {
-          "label": "Alder",
-          "verdi": 9
+        "fødselsnummer": {
+          "label": "Fødselsnummer (11 siffer) / d-nummer",
+          "verdi": {
+            "verdi": "28021078036"
+          },
+          "alternativer": null,
+          "svarId": null
         },
-        "fødselsdato": {
-          "label": "Fødselsdato",
-          "verdi": "2010-02-28"
-        },
-        "harSammeAdresse": {
+        "harSkalHaSammeAdresse": {
           "label": "Har barnet samme adresse som deg?",
-          "verdi": true
+          "verdi": true,
+          "alternativer": null,
+          "svarId": null
         },
-        "født": {
+        "ikkeRegistrertPåSøkersAdresseBeskrivelse": null,
+        "erBarnetFødt": {
           "label": "Er barnet født?",
-          "verdi": true
+          "verdi": true,
+          "alternativer": null,
+          "svarId": null
         },
-        "forelder": {
-          "kanIkkeOppgiAnnenForelderFar": {
-            "label": "Kan ikke oppgi annen forelder",
-            "verdi": false
+        "fødselTermindato": {
+          "label": "Fødselsdato",
+          "verdi": "2010-02-28",
+          "alternativer": null,
+          "svarId": null
+        },
+        "terminbekreftelse": null,
+        "annenForelder": {
+          "label": "Barnets andre forelder",
+          "verdi": {
+            "ikkeOppgittAnnenForelderBegrunnelse": null,
+            "person": {
+              "label": "Persondata",
+              "verdi": {
+                "navn": {
+                  "label": "halla",
+                  "verdi": "Ola N",
+                  "alternativer": null,
+                  "svarId": null
+                },
+                "fødselsnummer": null,
+                "fødselsdato": null,
+                "land": null
+              },
+              "alternativer": null,
+              "svarId": null
+            },
+            "bosattNorge": {
+              "label": "Bor [0]s andre forelder i Norge?",
+              "verdi": true,
+              "alternativer": null,
+              "svarId": null
+            },
+            "land": null
           },
-          "navn": {
-            "label": "halla",
-            "verdi": "Ola N"
+          "alternativer": null,
+          "svarId": null
+        },
+        "samvær": {
+          "label": "Samvær",
+          "verdi": {
+            "skalAnnenForelderHaSamvær": {
+              "label": "Har den andre forelderen samvær med [0]?",
+              "verdi": "Nei",
+              "alternativer": null,
+              "svarId": "nei"
+            },
+            "harDereSkriftligAvtaleOmSamvær": {
+              "label": "Har dere sktiflig samværsavtale?",
+              "verdi": "Nei",
+              "alternativer": null,
+              "svarId": "nei"
+            },
+            "samværsavtale": null,
+            "skalBarnetBoHosSøkerMenAnnenForelderSamarbeiderIkke": null,
+            "hvordanPraktiseresSamværet": {
+              "label": "Hvordan praktiseres samværet?",
+              "verdi": "Praktiseres ikke",
+              "alternativer": null,
+              "svarId": "nei"
+            },
+            "borAnnenForelderISammeHus": {
+              "label": "Bor du og den andre forelderen til [0] i samme hus, blokk, gårdstun, kvartal eller vei/gate?",
+              "verdi": "Nei",
+              "alternativer": null,
+              "svarId": null
+            },
+            "borAnnenForelderISammeHusBeskrivelse": null,
+            "harDereTidligereBoddSammen": {
+              "label": "Har du bodd sammen med den andre forelderen til [0] før?",
+              "verdi": false,
+              "alternativer": null,
+              "svarId": null
+            },
+            "nårFlyttetDereFraHverandre": {
+              "label": "Flyttet fra",
+              "verdi": "2000-04-22",
+              "alternativer": null,
+              "svarId": null
+            },
+            "erklæringOmSamlivsbrudd": null,
+            "hvorMyeErDuSammenMedAnnenForelder": {
+              "label": "Hvor mye er du sammen med den andre forelderen til Solveig?",
+              "verdi": "Vi møtes ikke",
+              "alternativer": null,
+              "svarId": null
+            },
+            "beskrivSamværUtenBarn": {
+              "label": "Har den andre forelderen samvær med [0]?",
+              "verdi": "Vi møtes nå og da, gjerne for en tur i skogen eller et glass vin, hyggelig det.",
+              "alternativer": null,
+              "svarId": null
+            }
           },
-          "personnr": {
-            "label": "Personnr",
-            "verdi": "01056638934"
-          },
-          "borINorge": {
-            "spørsmålid": "borINorge",
-            "svarid": "JA",
-            "label": "Bor [0]s andre forelder i Norge?",
-            "verdi": true
-          },
-          "borAnnenForelderISammeHus": {
-            "label": "Bor du og den andre forelderen til [0] i samme hus, blokk, gårdstun, kvartal eller vei/gate?",
-            "verdi": "Nei"
-          },
-          "boddSammenFør": {
-            "spørsmålid": "boddSammenFør",
-            "svarid": "NEI",
-            "label": "Har du bodd sammen med den andre forelderen til [0] før?",
-            "verdi": false
-          },
-          "flyttetFra": {
-            "label": "Flyttet fra",
-            "verdi": "2000-04-22"
-          },
-          "hvorMyeSammen": {
-            "label": "Hvor mye er du sammen med den andre forelderen til Solveig?",
-            "verdi": "Vi møtes ikke"
-          },
-          "harAnnenForelderSamværMedBarn": {
-            "spørsmålid": "harAnnenForelderSamværMedBarn",
-            "svarid": "nei",
-            "label": "Har den andre forelderen samvær med [0]?",
-            "verdi": "Nei"
-          },
-          "harDereSkriftligSamværsavtale": {
-            "spørsmålid": "harDereSkriftligSamværsavtale",
-            "svarid": "nei",
-            "label": "Har dere sktiflig samværsavtale?",
-            "verdi": "Nei"
-          },
-          "hvordanPraktiseresSamværet": {
-            "spørsmålid": "hvordanPraktiseresSamværet",
-            "svarid": "nei",
-            "label": "Hvordan praktiseres samværet?",
-            "verdi": "Praktiseres ikke"
-          },
-          "beskrivSamværUtenBarn": {
-            "label": "Har den andre forelderen samvær med [0]?",
-            "verdi": "Vi møtes nå og da, gjerne for en tur i skogen eller et glass vin, hyggelig det."
-          }
+          "alternativer": null,
+          "svarId": null
         },
         "skalHaBarnepass": {
           "label": "Skal barnet være med i søknaden?",
-          "verdi": true
-        }
-      },
-      {
-        "personnummer": {
-          "label": "Personnummer",
-          "verdi": "12345678913"
+          "verdi": true,
+          "alternativer": null,
+          "svarId": null
         },
-        "alder": {
-          "label": "Alder",
-          "verdi": 0
-        },
-        "navn": {
-          "label": "Navn",
-          "verdi": "Nyadoptert"
-        },
-        "fødselsdato": {
-          "label": "Fødselsdato",
-          "verdi": "2020-04-22"
-        },
-        "harSammeAdresse": {
-          "label": "Er barnet født?",
-          "verdi": true
-        },
-        "født": {
-          "spørsmålid": "født",
-          "svarid": "JA",
-          "label": "Er barnet født?",
-          "verdi": true
-        },
-        "lagtTil": true,
-        "skalBarnBoHosDeg": {
-          "label": "skalBarnetBoHosSøker?",
-          "verdi": true
-        },
-        "id": "16405e7a-3104-4cf7-bc53-3612ce99c5ee",
-        "forelder": {
-          "kanIkkeOppgiAnnenForelderFar": {
-            "label": "Kan ikke oppgi annen forelder",
-            "verdi": true
-          },
-          "ikkeOppgittAnnenForelderBegrunnelse": {
-            "label": "Kan ikke oppgi annen forelder",
-            "verdi": "Ingen kommentar"
-          },
-          "navn": {
-            "label": "halla",
-            "verdi": "Ola N"
-          },
-          "personnr": {
-            "label": "Personnr",
-            "verdi": "01056638934"
-          },
-          "borINorge": {
-            "spørsmålid": "borINorge",
-            "svarid": "JA",
-            "label": "Bor [0]s andre forelder i Norge?",
-            "verdi": true
-          },
-          "borISammeHus": {
-            "label": "Bor du og den andre forelderen til [0] i samme hus, blokk, gårdstun, kvartal eller vei/gate?",
-            "verdi": "Nei"
-          },
-          "boddSammenFør": {
-            "spørsmålid": "boddSammenFør",
-            "svarid": "NEI",
-            "label": "Har du bodd sammen med den andre forelderen til [0] før?",
-            "verdi": false
-          },
-          "hvorMyeSammen": {
-            "label": "Hvor mye er du sammen med den andre forelderen til Solveig?",
-            "verdi": "Vi møtes ikke"
-          },
-          "harAnnenForelderSamværMedBarn": {
-            "spørsmålid": "harAnnenForelderSamværMedBarn",
-            "svarid": "nei",
-            "label": "Har den andre forelderen samvær med [0]?",
-            "verdi": "Nei"
-          }
-        },
-        "Skal barnet være med i søknaden?": {
-          "label": "",
-          "verdi": true
-        },
-        "barnepass": {
-          "barnepassordninger": [
-            {
-              "id": "04f7b52c-3bc0-47f9-bda8-beb3d5226725",
-              "hvaSlagsBarnepassOrdning": {
-                "spørsmålid": "hvaSlagsBarnepassOrdning",
-                "svarid": "barnehageOgLiknende",
-                "label": "Hva slags barnepassordning har [0]?",
-                "verdi": "Barnehage, SFO eller liknende"
-              },
-              "navn": {
-                "label": "Navn på barnepassordningen eller personen som passer KARAFFEL STERK",
-                "verdi": "asd"
-              },
-              "periode": {
-                "label": "I hvilken periode har KARAFFEL STERK denne barnepassordningen?",
-                "fra": {
-                  "label": "I hvilken periode har KARAFFEL STERK denne barnepassordningen?",
-                  "verdi": "2020-07-08T22:00:00.000Z"
-                },
-                "til": {
-                  "label": "I hvilken periode har KARAFFEL STERK denne barnepassordningen?",
-                  "verdi": "2020-07-29T22:00:00.000Z"
-                }
-              },
-              "belop": {
-                "label": "Beløp pr måned (ikke inkludert kost)",
-                "verdi": "1234"
-              }
-            }
-          ]
-        }
-      }
-    ]
-  },
-  "sivilstatus": {
-    "harSøktSeparasjon": {
-      "label": "Søker har søkt separasjon",
-      "verdi": false
-    },
-    "datoSøktSeparasjon": {
-      "label": "Dato for samlivsbrudd",
-      "verdi": "2020-01-01"
-    },
-    "erUformeltGift": {
-      "label": "Søker gift i utlandet",
-      "verdi": false
-    },
-    "erUformeltSeparertEllerSkilt": {
-      "label": "søker Separert Eller Skilt I Utlandet",
-      "verdi": true
-    },
-    "årsakEnslig": {
-      "label": "årsakEnslig",
-      "verdi": "Jeg trenger hjelp"
-    },
-    "datoForSamlivsbrudd": {
-      "label": "Dato for samlivsbrudd",
-      "verdi": "2014-10-03"
-    },
-    "datoFlyttetFraHverandre": {
-      "label": "datoFlyttetFraHverandre",
-      "verdi": "2014-10-04"
-    },
-    "datoEndretSamvær": {
-      "label": "datoEndretSamvær",
-      "verdi": "2014-10-05"
-    },
-    "tidligereSamboerDetaljer": {
-      "navn": {
-        "label": "Navn",
-        "verdi": "Pelle proff"
-      },
-      "fødselsdato": {
-        "label": "Fødselsdato",
-        "verdi": "2020-05-31T22:00:00.000Z"
-      }
-    }
-  },
-  "medlemskap": {
-    "søkerOppholderSegINorge": {
-      "label": "Oppholder du deg i Norge?",
-      "verdi": true
-    },
-    "søkerBosattINorgeSisteTreÅr": {
-      "label": "Har du vært bosatt i Norge de siste tre årene?",
-      "verdi": false
-    },
-    "perioderBoddIUtlandet": [
-      {
-        "react_key": "83637c0a-faca-40c3-85db-f7898662e7f0",
-        "periode": {
-          "fra": {
-            "label": "Fra",
-            "verdi": "2019-05-01T08:02:03.000Z"
-          },
-          "til": {
-            "label": "Til",
-            "verdi": "2019-10-01T08:02:03.000Z"
-          }
-        },
-        "begrunnelse": {
-          "label": "Hvorfor bodde du i utlandet?",
-          "verdi": "Jobbet litt"
-        }
-      },
-      {
-        "react_key": "32fad487-3b05-448e-a2c1-2adac7f5c8e5",
-        "periode": {
-          "fra": {
-            "label": "Fra",
-            "verdi": "2019-11-27T09:02:03.000Z"
-          },
-          "til": {
-            "label": "Til",
-            "verdi": "2020-02-01T09:02:03.000Z"
-          }
-        },
-        "begrunnelse": {
-          "label": "Hvorfor bodde du i utlandet?",
-          "verdi": "Jobbet mer"
-        }
-      }
-    ]
-  },
-  "bosituasjon": {
-    "delerBoligMedAndreVoksne": {
-      "label": "Deler du bolig med andre voksne?",
-      "verdi": "Nei, jeg bor alene med barn eller jeg er gravid og bor alene"
-    },
-    "datoFlyttetSammenMedSamboer": {
-      "label": "Label",
-      "verdi": "2020-01-01"
-    },
-    "skalGifteSegEllerBliSamboer": {
-      "label": "Har du konkrete planer om å gifte deg eller bli samboer?",
-      "verdi": false
-    },
-    "datoSkalGifteSegEllerBliSamboer": {
-      "label": "Dato skal gifte seg eller bli samboer",
-      "verdi": "2020-01-01"
-    },
-    "samboerDetaljer": {
-      "navn": {
-        "label": "Navn",
-        "verdi": "Pelle proff"
-      },
-      "fødselsdato": {
-        "label": "Fødselsdato",
-        "verdi": "2020-05-31T22:00:00.000Z"
-      }
-    },
-    "datoFlyttetFraHverandre": {
-      "label": "datoFlyttetFraHverandre",
-      "verdi": "2014-10-04"
-    }
-  },
-  "dokumentasjonsbehov": [
-    {
-      "id": "INNGÅTT_EKTESKAP",
-      "spørsmålid": "erUformeltGift",
-      "svarid": "JA",
-      "tittel": "dokumentasjon.inngåttEkteskap.tittel",
-      "beskrivelse": "dokumentasjon.inngåttEkteskap.beskrivelse",
-      "harSendtInn": false,
-      "label": "Dokumentasjon på inngått ekteskap",
-      "opplastedeVedlegg": [
-        {
-          "dokumentId": "56ca1b13-9167-4ff4-98a6-f34b8fc8a95d",
-          "navn": "Avtalebetingelser_23.pdf",
-          "størrelse": 138439
-        },
-        {
-          "dokumentId": "a60c026a-ac2b-4b70-8cc3-bbe0d8e94e67",
-          "navn": "Avtalebetingelser_23.pdf",
-          "størrelse": 138439
-        },
-        {
-          "dokumentId": "9480ca05-f19e-4eb8-9219-d7b7bdc857fd",
-          "navn": "Treningsopplegg09_06_2020.pdf",
-          "størrelse": 540420
-        }
-      ]
-    },
-    {
-      "id": "BOR_PÅ_ULIKE_ADRESSER",
-      "spørsmålid": "delerBoligMedAndreVoksne",
-      "svarid": "tidligereSamboerFortsattRegistrertPåAdresse",
-      "tittel": "dokumentasjon.ulikeAdresser.tittel",
-      "beskrivelse": "dokumentasjon.ulikeAdresser.beskrivelse",
-      "label": "Bor på ulike adresser",
-      "harSendtInn": false
-    },
-    {
-      "id": "SYKDOM",
-      "spørsmålid": "gjelderDetteDeg",
-      "svarid": "erSyk",
-      "tittel": "dokumentasjon.sykdom.tittel",
-      "beskrivelse": "dokumentasjon.sykdom.beskrivelse",
-      "label": "Sykdom",
-      "harSendtInn": false
-    },
-    {
-      "id": "UTDANNING",
-      "spørsmålid": "gjelderDetteDeg",
-      "svarid": "skalTaUtdanning",
-      "tittel": "dokumentasjon.utdanning.tittel",
-      "beskrivelse": "dokumentasjon.utdanning.beskrivelse",
-      "harSendtInn": false,
-      "label": "Dokumentasjon på utdanningen du skal ta",
-      "opplastedeVedlegg": [
-        {
-          "dokumentId": "a8368a39-e80d-48e5-9160-fee3d1bd2ecb",
-          "navn": "Avtalebetingelser_23.pdf",
-          "størrelse": 138439
-        },
-        {
-          "dokumentId": "0647c95c-c2c3-4789-8eaf-8440fbc67feb",
-          "navn": "Kontrakt-1954   1-VH98825_encrypted_.pdf",
-          "størrelse": 62841
-        }
-      ]
-    }
-  ],
-  "aktivitet": {
-    "datoOppstartJobb": {
-      "label": "Når skal du starte i ny jobb?",
-      "verdi": "2020-03-27T13:52:42.742Z"
-    },
-    "hvaErDinArbeidssituasjon": {
-      "label": "Hva er din arbeidsituasjon?",
-      "verdi": [
-        "Jeg er hjemme med barn under 1 år",
-        "Jeg er arbeidstaker",
-        "Jeg er selvstendig næringsdrivende eller frilanser",
-        "Jeg er ansatt i eget AS",
-        "Jeg etablerer egen virksomhet",
-        "Jeg er arbeidssøker",
-        "Jeg tar utdanning",
-        "Jeg er hverken i arbeid, utdanning eller er arbeidssøker",
-        "Jeg er syk",
-        "Barnet mitt er sykt",
-        "Jeg har søkt om barnepass, men ikke fått plass enda",
-        "Jeg har barn som har behov for særlig tilsyn på grunn av fysiske, psykiske eller store sosiale problemer",
-        "Jeg har fått tilbud om jobb",
-        "Jeg skal begynne å ta utdanning"
-      ]
-    },
-    "arbeidsforhold": [
-      {
-        "id": "3e1fdc94-e163-4f95-8d8e-05b552d9fabc",
-        "navn": {
-          "label": "Navn på arbeidsgiver",
-          "verdi": "Nav"
-        },
-        "arbeidsmengde": {
-          "label": "Hvor mye jobber du?",
-          "verdi": "23"
-        },
-        "ansettelsesforhold": {
-          "spørsmålid": "ansettelsesforhold",
-          "svarid": "fast",
-          "label": "Hva slags ansettelsesforhold har du?",
-          "verdi": "Fast"
-        },
-        "harSluttDato": {
-          "label": "Har du en sluttdato?",
-          "verdi": true
-        },
-        "sluttdato": {
-          "label": "Når skal du slutte?",
-          "verdi": "2020-03-31T06:33:41.000Z"
-        }
+        "særligeTilsynsbehov": null,
+        "barnepass": null,
+        "lagtTilManuelt": false,
+        "skalBarnetBoHosSøker": null
       }
     ],
-    "firma": {
-      "etableringsdato": {
-        "label": "Etableringsdato",
-        "verdi": "2020-03-27T13:52:42.742Z"
+    "alternativer": null,
+    "svarId": null
+  },
+  "aktivitet": {
+    "label": "Arbeid, utdanning og andre aktiviteter",
+    "verdi": {
+      "erIArbeid": null,
+      "hvordanErArbeidssituasjonen": {
+        "label": "Hva er din arbeidsituasjon?",
+        "verdi": [
+          "Jeg er hjemme med barn under 1 år",
+          "Jeg er arbeidstaker",
+          "Jeg er selvstendig næringsdrivende eller frilanser",
+          "Jeg er ansatt i eget AS",
+          "Jeg etablerer egen virksomhet",
+          "Jeg er arbeidssøker",
+          "Jeg tar utdanning",
+          "Jeg er hverken i arbeid, utdanning eller er arbeidssøker",
+          "Jeg er syk",
+          "Barnet mitt er sykt",
+          "Jeg har søkt om barnepass, men ikke fått plass enda",
+          "Jeg har barn som har behov for særlig tilsyn på grunn av fysiske, psykiske eller store sosiale problemer",
+          "Jeg har fått tilbud om jobb",
+          "Jeg skal begynne å ta utdanning"
+        ],
+        "alternativer": null,
+        "svarId": null
       },
-      "navn": {
-        "label": "Navn på arbeidsgiver",
-        "verdi": "Boller og brus"
-      },
-      "organisasjonsnummer": {
-        "label": "Organisasjonsnummer",
-        "verdi": "123"
-      },
-      "arbeidsmengde": {
-        "label": "Arbeidsmengde",
-        "verdi": "34"
-      },
-      "arbeidsuke": {
-        "label": "Arbeidsukebeskrivelse",
-        "verdi": "Jobber mandager"
-      }
-    },
-    "etablererEgenVirksomhet": {
-      "label": "Hva er din arbeidsituasjon?",
-      "verdi": "Dette er en spennende gründerbedrift"
-    },
-    "arbeidssøker": {
-      "registrertSomArbeidssøkerNav": {
-        "label": "Er du registrert som arbeidssøker hos Nav?",
-        "verdi": true
-      },
-      "villigTilÅTaImotTilbudOmArbeid": {
-        "label": "Er du villig til å ta imot tilbud om arbeid eller arbeidsmarkedstiltak?",
-        "verdi": true
-      },
-      "kanBegynneInnenEnUke": {
-        "label": "Kan du begynne i arbeid senest én uke etter at du har fått tilbud om jobb?",
-        "verdi": true
-      },
-      "kanSkaffeBarnepassInnenEnUke": {
-        "label": "Har du eller kan du skaffe barnepass senest innen en uke etter at du har fått tilbud om jobb eller arbeidsmarkedtiltak?",
-        "verdi": true
-      },
-      "hvorØnskerSøkerArbeid": {
-        "label": "Hvor ønsker du å søke arbeid?",
-        "verdi": "Hvor som helst i landet"
-      },
-      "ønskerSøker50ProsentStilling": {
-        "label": "Ønsker du å stå som arbeidssøker til minst 50% stilling?",
-        "verdi": true
-      }
-    },
-    "underUtdanning": {
-      "react_key": "cd87ae81-9885-40e3-92b7-bb2764553544",
-      "skoleUtdanningssted": {
-        "label": "Skole / utdanningssted",
-        "verdi": "Skoleskolen"
-      },
-      "linjeKursGrad": {
-        "label": "Linje / kurs / grad",
-        "verdi": "Stor kurs grad"
-      },
-      "offentligEllerPrivat": {
-        "label": "Er utdanningen privat eller offentlig?",
-        "verdi": "Offentlig"
-      },
-      "periode": {
-        "fra": {
-          "label": "",
-          "verdi": "2020-03-26T13:52:42.742Z"
-        },
-        "til": {
-          "label": "",
-          "verdi": "2020-03-27T13:52:42.742Z"
-        }
-      },
-      "heltidEllerDeltid": {
-        "label": "Er utdanningen på heltid eller deltid?",
-        "verdi": "Deltid"
-      },
-      "arbeidsmengde": {
-        "label": "Hvor mye skal du studere?",
-        "verdi": "50"
-      },
-      "målMedUtdanning": {
-        "label": "Hva er målet med utdanningen?",
-        "verdi": "Bli flink"
-      },
-      "harTattUtdanningEtterGrunnskolen": {
-        "label": "Har du tatt utdanning etter grunnskolen",
-        "verdi": true
-      },
-      "tidligereUtdanning": [
-        {
-          "react_key": "ab8d1628-18c0-40ec-9806-4adfba38be4e",
-          "linjeKursGrad": {
-            "label": "Linje / kurs / grad",
-            "verdi": "Skole ting"
-          },
-          "periode": {
-            "fra": {
-              "label": "",
-              "verdi": "2020-03-26T13:52:42.742Z"
+      "arbeidsforhold": {
+        "label": "Om arbeidsforholdet ditt",
+        "verdi": [
+          {
+            "arbeidsgivernavn": {
+              "label": "Navn på arbeidsgiver",
+              "verdi": "Nav",
+              "alternativer": null,
+              "svarId": null
             },
-            "til": {
-              "label": "utdanning.datovelger.studieperiode",
-              "verdi": "2020-03-27T13:52:42.742Z"
+            "arbeidsmengde": {
+              "label": "Hvor mye jobber du?",
+              "verdi": 23,
+              "alternativer": null,
+              "svarId": null
+            },
+            "fastEllerMidlertidig": {
+              "label": "Hva slags ansettelsesforhold har du?",
+              "verdi": "Fast",
+              "alternativer": null,
+              "svarId": "fast"
+            },
+            "harSluttdato": {
+              "label": "Har du en sluttdato?",
+              "verdi": true,
+              "alternativer": null,
+              "svarId": null
+            },
+            "sluttdato": {
+              "label": "Når skal du slutte?",
+              "verdi": "2020-03-31",
+              "alternativer": null,
+              "svarId": null
             }
           }
-        }
-      ]
-    },
-    "egetAS": [
-      {
-        "id": "fe2c0070-7f95-4b0d-939a-5f1298d1826b",
-        "navn": {
-          "label": "Navn på aksjeselskapet ditt",
-          "verdi": "Mitt eget AS"
+        ],
+        "alternativer": null,
+        "svarId": null
+      },
+      "selvstendig": null,
+      "firmaer": null,
+      "virksomhet": {
+        "label": "Om virksomheten du etablerer",
+        "verdi": {
+          "virksomhetsbeskrivelse": {
+            "label": "Hva er din arbeidsituasjon?",
+            "verdi": "Dette er en spennende gründerbedrift",
+            "alternativer": null,
+            "svarId": null
+          },
+          "dokumentasjon": null
         },
-        "arbeidsmengde": {
-          "label": "Hvor mye jobber du?",
-          "verdi": "55"
-        }
+        "alternativer": null,
+        "svarId": null
+      },
+      "arbeidssøker": {
+        "label": "Når du er arbeidssøker",
+        "verdi": {
+          "registrertSomArbeidssøkerNav": {
+            "label": "Er du registrert som arbeidssøker hos Nav?",
+            "verdi": true,
+            "alternativer": null,
+            "svarId": null
+          },
+          "villigTilÅTaImotTilbudOmArbeid": {
+            "label": "Er du villig til å ta imot tilbud om arbeid eller arbeidsmarkedstiltak?",
+            "verdi": true,
+            "alternativer": null,
+            "svarId": null
+          },
+          "kanDuBegynneInnenEnUke": {
+            "label": "Kan du begynne i arbeid senest én uke etter at du har fått tilbud om jobb?",
+            "verdi": true,
+            "alternativer": null,
+            "svarId": null
+          },
+          "kanDuSkaffeBarnepassInnenEnUke": {
+            "label": "Har du eller kan du skaffe barnepass senest innen en uke etter at du har fått tilbud om jobb eller arbeidsmarkedtiltak?",
+            "verdi": true,
+            "alternativer": null,
+            "svarId": null
+          },
+          "hvorØnskerDuArbeid": {
+            "label": "Hvor ønsker du å søke arbeid?",
+            "verdi": "Hvor som helst i landet",
+            "alternativer": null,
+            "svarId": null
+          },
+          "ønskerDuMinst50ProsentStilling": {
+            "label": "Ønsker du å stå som arbeidssøker til minst 50% stilling?",
+            "verdi": true,
+            "alternativer": null,
+            "svarId": null
+          },
+          "ikkeVilligTilÅTaImotTilbudOmArbeidDokumentasjon": null
+        },
+        "alternativer": null,
+        "svarId": null
+      },
+      "underUtdanning": {
+        "label": "Utdanningen du skal ta",
+        "verdi": {
+          "skoleUtdanningssted": {
+            "label": "Skole / utdanningssted",
+            "verdi": "Skoleskolen",
+            "alternativer": null,
+            "svarId": null
+          },
+          "utdanning": null,
+          "gjeldendeUtdanning": {
+            "label": "Utdanning",
+            "verdi": {
+              "linjeKursGrad": {
+                "label": "Linje / kurs / grad",
+                "verdi": "Stor kurs grad",
+                "alternativer": null,
+                "svarId": null
+              },
+              "nårVarSkalDuVæreElevStudent": {
+                "label": "Når skal du være elev/student?",
+                "verdi": {
+                  "fra": "2020-03-26",
+                  "til": "2020-03-27"
+                },
+                "alternativer": null,
+                "svarId": null
+              }
+            },
+            "alternativer": null,
+            "svarId": null
+          },
+          "offentligEllerPrivat": {
+            "label": "Er utdanningen privat eller offentlig?",
+            "verdi": "Offentlig",
+            "alternativer": null,
+            "svarId": null
+          },
+          "heltidEllerDeltid": {
+            "label": "Er utdanningen på heltid eller deltid?",
+            "verdi": "Deltid",
+            "alternativer": null,
+            "svarId": null
+          },
+          "hvorMyeSkalDuStudere": {
+            "label": "Hvor mye skal du studere?",
+            "verdi": 50,
+            "alternativer": null,
+            "svarId": null
+          },
+          "hvaErMåletMedUtdanningen": {
+            "label": "Hva er målet med utdanningen?",
+            "verdi": "Bli flink",
+            "alternativer": null,
+            "svarId": null
+          },
+          "utdanningEtterGrunnskolen": {
+            "label": "Har du tatt utdanning etter grunnskolen",
+            "verdi": true,
+            "alternativer": null,
+            "svarId": null
+          },
+          "tidligereUtdanninger": {
+            "label": "Tidligere Utdanning",
+            "verdi": [
+              {
+                "linjeKursGrad": {
+                  "label": "Linje / kurs / grad",
+                  "verdi": "Skole ting",
+                  "alternativer": null,
+                  "svarId": null
+                },
+                "nårVarSkalDuVæreElevStudent": {
+                  "label": "Når var du elev/student?",
+                  "verdi": {
+                    "fraMåned": "MARCH",
+                    "fraÅr": 2020,
+                    "tilMåned": "MARCH",
+                    "tilÅr": 2020
+                  },
+                  "alternativer": null,
+                  "svarId": null
+                }
+              }
+            ],
+            "alternativer": null,
+            "svarId": null
+          },
+          "semesteravgift": null,
+          "studieavgift": null,
+          "eksamensgebyr": null
+        },
+        "alternativer": null,
+        "svarId": null
+      },
+      "aksjeselskap": {
+        "label": "Om aksjeselskapet ditt",
+        "verdi": [
+          {
+            "navn": {
+              "label": "Navn på aksjeselskapet ditt",
+              "verdi": "Mitt eget AS",
+              "alternativer": null,
+              "svarId": null
+            },
+            "arbeidsmengde": {
+              "label": "Hvor mye jobber du?",
+              "verdi": 55,
+              "alternativer": null,
+              "svarId": null
+            }
+          }
+        ],
+        "alternativer": null,
+        "svarId": null
+      },
+      "erIArbeidDokumentasjon": null
+    },
+    "alternativer": null,
+    "svarId": null
+  },
+  "stønadsstart": {
+    "label": "Når søker du stønad fra?",
+    "verdi": {
+      "søkerFraBestemtMåned": {
+        "label": "søkerFraBestemtMåned",
+        "verdi": true,
+        "alternativer": null,
+        "svarId": null
+      },
+      "fraMåned": {
+        "label": "Fra måned",
+        "verdi": "JANUARY",
+        "alternativer": null,
+        "svarId": null
+      },
+      "fraÅr": {
+        "label": "Fra år",
+        "verdi": 2020,
+        "alternativer": null,
+        "svarId": null
       }
-    ]
+    },
+    "alternativer": null,
+    "svarId": null
   },
-  "søkerFraBestemtMåned": {
-    "label": "søkerFraBestemtMåned",
-    "verdi": true
-  },
-  "søknadsdato": {
-    "label": "søknadsdato",
-    "verdi": "2020-01-01"
+  "dokumentasjon": {
+    "barnepassordningFaktura": null,
+    "avtaleBarnepasser": null,
+    "arbeidstid": null,
+    "roterendeArbeidstid": null,
+    "spesielleBehov": null
   }
 }

--- a/src/test/resources/barnetilsyn/Barnetilsynsøknad.json
+++ b/src/test/resources/barnetilsyn/Barnetilsynsøknad.json
@@ -447,7 +447,7 @@
               "label": "Hvor mye er du sammen med den andre forelderen til Solveig?",
               "verdi": "Vi møtes ikke",
               "alternativer": null,
-              "svarId": null
+              "svarId": "møtesIkke"
             },
             "beskrivSamværUtenBarn": {
               "label": "Har den andre forelderen samvær med [0]?",

--- a/src/test/resources/barnetilsyn/BarnetilsynsøknadDto.json
+++ b/src/test/resources/barnetilsyn/BarnetilsynsøknadDto.json
@@ -1,0 +1,608 @@
+{
+  "person": {
+    "søker": {
+      "fnr": "19128449828",
+      "forkortetNavn": "Kari Nordmann",
+      "adresse": {
+        "adresse": "Jerpefaret 5C",
+        "adressetillegg": "",
+        "kommune": "0104",
+        "postnummer": "1440"
+      },
+      "egenansatt": false,
+      "innvandretDato": null,
+      "utvandretDato": null,
+      "oppholdstillatelse": null,
+      "sivilstand": "UGIF",
+      "språk": "",
+      "statsborgerskap": "NOR",
+      "privattelefon": null,
+      "mobiltelefon": null,
+      "jobbtelefon": null,
+      "kontakttelefon": "99988877",
+      "bankkontonummer": null
+    },
+    "barn": [
+      {
+        "id": "12345",
+        "fnr": "28021078036",
+        "ident": {
+          "label": "Fødselsnummer (11 siffer) / d-nummer",
+          "verdi": "28021078036"
+        },
+        "navn": {
+          "label": "Navn",
+          "verdi": "SHIBA INU"
+        },
+        "alder": {
+          "label": "Alder",
+          "verdi": 9
+        },
+        "fødselsdato": {
+          "label": "Fødselsdato",
+          "verdi": "2010-02-28"
+        },
+        "harSammeAdresse": {
+          "label": "Har barnet samme adresse som deg?",
+          "verdi": true
+        },
+        "født": {
+          "label": "Er barnet født?",
+          "verdi": true
+        },
+        "forelder": {
+          "kanIkkeOppgiAnnenForelderFar": {
+            "label": "Kan ikke oppgi annen forelder",
+            "verdi": false
+          },
+          "navn": {
+            "label": "halla",
+            "verdi": "Ola N"
+          },
+          "personnr": {
+            "label": "Personnr",
+            "verdi": "01056638934"
+          },
+          "borINorge": {
+            "spørsmålid": "borINorge",
+            "svarid": "JA",
+            "label": "Bor [0]s andre forelder i Norge?",
+            "verdi": true
+          },
+          "borAnnenForelderISammeHus": {
+            "label": "Bor du og den andre forelderen til [0] i samme hus, blokk, gårdstun, kvartal eller vei/gate?",
+            "verdi": "Nei"
+          },
+          "boddSammenFør": {
+            "spørsmålid": "boddSammenFør",
+            "svarid": "NEI",
+            "label": "Har du bodd sammen med den andre forelderen til [0] før?",
+            "verdi": false
+          },
+          "flyttetFra": {
+            "label": "Flyttet fra",
+            "verdi": "2000-04-22"
+          },
+          "hvorMyeSammen": {
+            "label": "Hvor mye er du sammen med den andre forelderen til Solveig?",
+            "verdi": "Vi møtes ikke"
+          },
+          "harAnnenForelderSamværMedBarn": {
+            "spørsmålid": "harAnnenForelderSamværMedBarn",
+            "svarid": "nei",
+            "label": "Har den andre forelderen samvær med [0]?",
+            "verdi": "Nei"
+          },
+          "harDereSkriftligSamværsavtale": {
+            "spørsmålid": "harDereSkriftligSamværsavtale",
+            "svarid": "nei",
+            "label": "Har dere sktiflig samværsavtale?",
+            "verdi": "Nei"
+          },
+          "hvordanPraktiseresSamværet": {
+            "spørsmålid": "hvordanPraktiseresSamværet",
+            "svarid": "nei",
+            "label": "Hvordan praktiseres samværet?",
+            "verdi": "Praktiseres ikke"
+          },
+          "beskrivSamværUtenBarn": {
+            "label": "Har den andre forelderen samvær med [0]?",
+            "verdi": "Vi møtes nå og da, gjerne for en tur i skogen eller et glass vin, hyggelig det."
+          }
+        },
+        "skalHaBarnepass": {
+          "label": "Skal barnet være med i søknaden?",
+          "verdi": true
+        }
+      },
+      {
+        "personnummer": {
+          "label": "Personnummer",
+          "verdi": "12345678913"
+        },
+        "alder": {
+          "label": "Alder",
+          "verdi": 0
+        },
+        "navn": {
+          "label": "Navn",
+          "verdi": "Nyadoptert"
+        },
+        "fødselsdato": {
+          "label": "Fødselsdato",
+          "verdi": "2020-04-22"
+        },
+        "harSammeAdresse": {
+          "label": "Er barnet født?",
+          "verdi": true
+        },
+        "født": {
+          "spørsmålid": "født",
+          "svarid": "JA",
+          "label": "Er barnet født?",
+          "verdi": true
+        },
+        "lagtTil": true,
+        "skalBarnBoHosDeg": {
+          "label": "skalBarnetBoHosSøker?",
+          "verdi": true
+        },
+        "id": "16405e7a-3104-4cf7-bc53-3612ce99c5ee",
+        "forelder": {
+          "kanIkkeOppgiAnnenForelderFar": {
+            "label": "Kan ikke oppgi annen forelder",
+            "verdi": true
+          },
+          "ikkeOppgittAnnenForelderBegrunnelse": {
+            "label": "Kan ikke oppgi annen forelder",
+            "verdi": "Ingen kommentar"
+          },
+          "navn": {
+            "label": "halla",
+            "verdi": "Ola N"
+          },
+          "personnr": {
+            "label": "Personnr",
+            "verdi": "01056638934"
+          },
+          "borINorge": {
+            "spørsmålid": "borINorge",
+            "svarid": "JA",
+            "label": "Bor [0]s andre forelder i Norge?",
+            "verdi": true
+          },
+          "borISammeHus": {
+            "label": "Bor du og den andre forelderen til [0] i samme hus, blokk, gårdstun, kvartal eller vei/gate?",
+            "verdi": "Nei"
+          },
+          "boddSammenFør": {
+            "spørsmålid": "boddSammenFør",
+            "svarid": "NEI",
+            "label": "Har du bodd sammen med den andre forelderen til [0] før?",
+            "verdi": false
+          },
+          "hvorMyeSammen": {
+            "label": "Hvor mye er du sammen med den andre forelderen til Solveig?",
+            "verdi": "Vi møtes ikke"
+          },
+          "harAnnenForelderSamværMedBarn": {
+            "spørsmålid": "harAnnenForelderSamværMedBarn",
+            "svarid": "nei",
+            "label": "Har den andre forelderen samvær med [0]?",
+            "verdi": "Nei"
+          }
+        },
+        "Skal barnet være med i søknaden?": {
+          "label": "",
+          "verdi": true
+        },
+        "barnepass": {
+          "barnepassordninger": [
+            {
+              "id": "04f7b52c-3bc0-47f9-bda8-beb3d5226725",
+              "hvaSlagsBarnepassOrdning": {
+                "spørsmålid": "hvaSlagsBarnepassOrdning",
+                "svarid": "barnehageOgLiknende",
+                "label": "Hva slags barnepassordning har [0]?",
+                "verdi": "Barnehage, SFO eller liknende"
+              },
+              "navn": {
+                "label": "Navn på barnepassordningen eller personen som passer KARAFFEL STERK",
+                "verdi": "asd"
+              },
+              "periode": {
+                "label": "I hvilken periode har KARAFFEL STERK denne barnepassordningen?",
+                "fra": {
+                  "label": "I hvilken periode har KARAFFEL STERK denne barnepassordningen?",
+                  "verdi": "2020-07-08T22:00:00.000Z"
+                },
+                "til": {
+                  "label": "I hvilken periode har KARAFFEL STERK denne barnepassordningen?",
+                  "verdi": "2020-07-29T22:00:00.000Z"
+                }
+              },
+              "belop": {
+                "label": "Beløp pr måned (ikke inkludert kost)",
+                "verdi": "1234"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "sivilstatus": {
+    "harSøktSeparasjon": {
+      "label": "Søker har søkt separasjon",
+      "verdi": false
+    },
+    "datoSøktSeparasjon": {
+      "label": "Dato for samlivsbrudd",
+      "verdi": "2020-01-01"
+    },
+    "erUformeltGift": {
+      "label": "Søker gift i utlandet",
+      "verdi": false
+    },
+    "erUformeltSeparertEllerSkilt": {
+      "label": "søker Separert Eller Skilt I Utlandet",
+      "verdi": true
+    },
+    "årsakEnslig": {
+      "label": "årsakEnslig",
+      "verdi": "Jeg trenger hjelp"
+    },
+    "datoForSamlivsbrudd": {
+      "label": "Dato for samlivsbrudd",
+      "verdi": "2014-10-03"
+    },
+    "datoFlyttetFraHverandre": {
+      "label": "datoFlyttetFraHverandre",
+      "verdi": "2014-10-04"
+    },
+    "datoEndretSamvær": {
+      "label": "datoEndretSamvær",
+      "verdi": "2014-10-05"
+    },
+    "tidligereSamboerDetaljer": {
+      "navn": {
+        "label": "Navn",
+        "verdi": "Pelle proff"
+      },
+      "fødselsdato": {
+        "label": "Fødselsdato",
+        "verdi": "2020-05-31T22:00:00.000Z"
+      }
+    }
+  },
+  "medlemskap": {
+    "søkerOppholderSegINorge": {
+      "label": "Oppholder du deg i Norge?",
+      "verdi": true
+    },
+    "søkerBosattINorgeSisteTreÅr": {
+      "label": "Har du vært bosatt i Norge de siste tre årene?",
+      "verdi": false
+    },
+    "perioderBoddIUtlandet": [
+      {
+        "react_key": "83637c0a-faca-40c3-85db-f7898662e7f0",
+        "periode": {
+          "fra": {
+            "label": "Fra",
+            "verdi": "2019-05-01T08:02:03.000Z"
+          },
+          "til": {
+            "label": "Til",
+            "verdi": "2019-10-01T08:02:03.000Z"
+          }
+        },
+        "begrunnelse": {
+          "label": "Hvorfor bodde du i utlandet?",
+          "verdi": "Jobbet litt"
+        }
+      },
+      {
+        "react_key": "32fad487-3b05-448e-a2c1-2adac7f5c8e5",
+        "periode": {
+          "fra": {
+            "label": "Fra",
+            "verdi": "2019-11-27T09:02:03.000Z"
+          },
+          "til": {
+            "label": "Til",
+            "verdi": "2020-02-01T09:02:03.000Z"
+          }
+        },
+        "begrunnelse": {
+          "label": "Hvorfor bodde du i utlandet?",
+          "verdi": "Jobbet mer"
+        }
+      }
+    ]
+  },
+  "bosituasjon": {
+    "delerBoligMedAndreVoksne": {
+      "label": "Deler du bolig med andre voksne?",
+      "verdi": "Nei, jeg bor alene med barn eller jeg er gravid og bor alene"
+    },
+    "datoFlyttetSammenMedSamboer": {
+      "label": "Label",
+      "verdi": "2020-01-01"
+    },
+    "skalGifteSegEllerBliSamboer": {
+      "label": "Har du konkrete planer om å gifte deg eller bli samboer?",
+      "verdi": false
+    },
+    "datoSkalGifteSegEllerBliSamboer": {
+      "label": "Dato skal gifte seg eller bli samboer",
+      "verdi": "2020-01-01"
+    },
+    "samboerDetaljer": {
+      "navn": {
+        "label": "Navn",
+        "verdi": "Pelle proff"
+      },
+      "fødselsdato": {
+        "label": "Fødselsdato",
+        "verdi": "2020-05-31T22:00:00.000Z"
+      }
+    },
+    "datoFlyttetFraHverandre": {
+      "label": "datoFlyttetFraHverandre",
+      "verdi": "2014-10-04"
+    }
+  },
+  "dokumentasjonsbehov": [
+    {
+      "id": "INNGÅTT_EKTESKAP",
+      "spørsmålid": "erUformeltGift",
+      "svarid": "JA",
+      "tittel": "dokumentasjon.inngåttEkteskap.tittel",
+      "beskrivelse": "dokumentasjon.inngåttEkteskap.beskrivelse",
+      "harSendtInn": false,
+      "label": "Dokumentasjon på inngått ekteskap",
+      "opplastedeVedlegg": [
+        {
+          "dokumentId": "56ca1b13-9167-4ff4-98a6-f34b8fc8a95d",
+          "navn": "Avtalebetingelser_23.pdf",
+          "størrelse": 138439
+        },
+        {
+          "dokumentId": "a60c026a-ac2b-4b70-8cc3-bbe0d8e94e67",
+          "navn": "Avtalebetingelser_23.pdf",
+          "størrelse": 138439
+        },
+        {
+          "dokumentId": "9480ca05-f19e-4eb8-9219-d7b7bdc857fd",
+          "navn": "Treningsopplegg09_06_2020.pdf",
+          "størrelse": 540420
+        }
+      ]
+    },
+    {
+      "id": "BOR_PÅ_ULIKE_ADRESSER",
+      "spørsmålid": "delerBoligMedAndreVoksne",
+      "svarid": "tidligereSamboerFortsattRegistrertPåAdresse",
+      "tittel": "dokumentasjon.ulikeAdresser.tittel",
+      "beskrivelse": "dokumentasjon.ulikeAdresser.beskrivelse",
+      "label": "Bor på ulike adresser",
+      "harSendtInn": false
+    },
+    {
+      "id": "SYKDOM",
+      "spørsmålid": "gjelderDetteDeg",
+      "svarid": "erSyk",
+      "tittel": "dokumentasjon.sykdom.tittel",
+      "beskrivelse": "dokumentasjon.sykdom.beskrivelse",
+      "label": "Sykdom",
+      "harSendtInn": false
+    },
+    {
+      "id": "UTDANNING",
+      "spørsmålid": "gjelderDetteDeg",
+      "svarid": "skalTaUtdanning",
+      "tittel": "dokumentasjon.utdanning.tittel",
+      "beskrivelse": "dokumentasjon.utdanning.beskrivelse",
+      "harSendtInn": false,
+      "label": "Dokumentasjon på utdanningen du skal ta",
+      "opplastedeVedlegg": [
+        {
+          "dokumentId": "a8368a39-e80d-48e5-9160-fee3d1bd2ecb",
+          "navn": "Avtalebetingelser_23.pdf",
+          "størrelse": 138439
+        },
+        {
+          "dokumentId": "0647c95c-c2c3-4789-8eaf-8440fbc67feb",
+          "navn": "Kontrakt-1954   1-VH98825_encrypted_.pdf",
+          "størrelse": 62841
+        }
+      ]
+    }
+  ],
+  "aktivitet": {
+    "datoOppstartJobb": {
+      "label": "Når skal du starte i ny jobb?",
+      "verdi": "2020-03-27T13:52:42.742Z"
+    },
+    "hvaErDinArbeidssituasjon": {
+      "label": "Hva er din arbeidsituasjon?",
+      "verdi": [
+        "Jeg er hjemme med barn under 1 år",
+        "Jeg er arbeidstaker",
+        "Jeg er selvstendig næringsdrivende eller frilanser",
+        "Jeg er ansatt i eget AS",
+        "Jeg etablerer egen virksomhet",
+        "Jeg er arbeidssøker",
+        "Jeg tar utdanning",
+        "Jeg er hverken i arbeid, utdanning eller er arbeidssøker",
+        "Jeg er syk",
+        "Barnet mitt er sykt",
+        "Jeg har søkt om barnepass, men ikke fått plass enda",
+        "Jeg har barn som har behov for særlig tilsyn på grunn av fysiske, psykiske eller store sosiale problemer",
+        "Jeg har fått tilbud om jobb",
+        "Jeg skal begynne å ta utdanning"
+      ]
+    },
+    "arbeidsforhold": [
+      {
+        "id": "3e1fdc94-e163-4f95-8d8e-05b552d9fabc",
+        "navn": {
+          "label": "Navn på arbeidsgiver",
+          "verdi": "Nav"
+        },
+        "arbeidsmengde": {
+          "label": "Hvor mye jobber du?",
+          "verdi": "23"
+        },
+        "ansettelsesforhold": {
+          "spørsmålid": "ansettelsesforhold",
+          "svarid": "fast",
+          "label": "Hva slags ansettelsesforhold har du?",
+          "verdi": "Fast"
+        },
+        "harSluttDato": {
+          "label": "Har du en sluttdato?",
+          "verdi": true
+        },
+        "sluttdato": {
+          "label": "Når skal du slutte?",
+          "verdi": "2020-03-31T06:33:41.000Z"
+        }
+      }
+    ],
+    "firma": {
+      "etableringsdato": {
+        "label": "Etableringsdato",
+        "verdi": "2020-03-27T13:52:42.742Z"
+      },
+      "navn": {
+        "label": "Navn på arbeidsgiver",
+        "verdi": "Boller og brus"
+      },
+      "organisasjonsnummer": {
+        "label": "Organisasjonsnummer",
+        "verdi": "123"
+      },
+      "arbeidsmengde": {
+        "label": "Arbeidsmengde",
+        "verdi": "34"
+      },
+      "arbeidsuke": {
+        "label": "Arbeidsukebeskrivelse",
+        "verdi": "Jobber mandager"
+      }
+    },
+    "etablererEgenVirksomhet": {
+      "label": "Hva er din arbeidsituasjon?",
+      "verdi": "Dette er en spennende gründerbedrift"
+    },
+    "arbeidssøker": {
+      "registrertSomArbeidssøkerNav": {
+        "label": "Er du registrert som arbeidssøker hos Nav?",
+        "verdi": true
+      },
+      "villigTilÅTaImotTilbudOmArbeid": {
+        "label": "Er du villig til å ta imot tilbud om arbeid eller arbeidsmarkedstiltak?",
+        "verdi": true
+      },
+      "kanBegynneInnenEnUke": {
+        "label": "Kan du begynne i arbeid senest én uke etter at du har fått tilbud om jobb?",
+        "verdi": true
+      },
+      "kanSkaffeBarnepassInnenEnUke": {
+        "label": "Har du eller kan du skaffe barnepass senest innen en uke etter at du har fått tilbud om jobb eller arbeidsmarkedtiltak?",
+        "verdi": true
+      },
+      "hvorØnskerSøkerArbeid": {
+        "label": "Hvor ønsker du å søke arbeid?",
+        "verdi": "Hvor som helst i landet"
+      },
+      "ønskerSøker50ProsentStilling": {
+        "label": "Ønsker du å stå som arbeidssøker til minst 50% stilling?",
+        "verdi": true
+      }
+    },
+    "underUtdanning": {
+      "react_key": "cd87ae81-9885-40e3-92b7-bb2764553544",
+      "skoleUtdanningssted": {
+        "label": "Skole / utdanningssted",
+        "verdi": "Skoleskolen"
+      },
+      "linjeKursGrad": {
+        "label": "Linje / kurs / grad",
+        "verdi": "Stor kurs grad"
+      },
+      "offentligEllerPrivat": {
+        "label": "Er utdanningen privat eller offentlig?",
+        "verdi": "Offentlig"
+      },
+      "periode": {
+        "fra": {
+          "label": "",
+          "verdi": "2020-03-26T13:52:42.742Z"
+        },
+        "til": {
+          "label": "",
+          "verdi": "2020-03-27T13:52:42.742Z"
+        }
+      },
+      "heltidEllerDeltid": {
+        "label": "Er utdanningen på heltid eller deltid?",
+        "verdi": "Deltid"
+      },
+      "arbeidsmengde": {
+        "label": "Hvor mye skal du studere?",
+        "verdi": "50"
+      },
+      "målMedUtdanning": {
+        "label": "Hva er målet med utdanningen?",
+        "verdi": "Bli flink"
+      },
+      "harTattUtdanningEtterGrunnskolen": {
+        "label": "Har du tatt utdanning etter grunnskolen",
+        "verdi": true
+      },
+      "tidligereUtdanning": [
+        {
+          "react_key": "ab8d1628-18c0-40ec-9806-4adfba38be4e",
+          "linjeKursGrad": {
+            "label": "Linje / kurs / grad",
+            "verdi": "Skole ting"
+          },
+          "periode": {
+            "fra": {
+              "label": "",
+              "verdi": "2020-03-26T13:52:42.742Z"
+            },
+            "til": {
+              "label": "utdanning.datovelger.studieperiode",
+              "verdi": "2020-03-27T13:52:42.742Z"
+            }
+          }
+        }
+      ]
+    },
+    "egetAS": [
+      {
+        "id": "fe2c0070-7f95-4b0d-939a-5f1298d1826b",
+        "navn": {
+          "label": "Navn på aksjeselskapet ditt",
+          "verdi": "Mitt eget AS"
+        },
+        "arbeidsmengde": {
+          "label": "Hvor mye jobber du?",
+          "verdi": "55"
+        }
+      }
+    ]
+  },
+  "søkerFraBestemtMåned": {
+    "label": "søkerFraBestemtMåned",
+    "verdi": true
+  },
+  "søknadsdato": {
+    "label": "søknadsdato",
+    "verdi": "2020-01-01"
+  }
+}


### PR DESCRIPTION
Sørger for at bruker ikke kan gjenbruke forrige søknad dersom det finnes ugyldige svarIds, altså verdier som ikke finnes i SvarId enum som er opprettet. Det må fortsatt undersøkes hvorfor disse ugyldige verdiene oppstår (typisk "null" som string), lager en egen Favro-oppgave for dette.

Testet med testperson: 30438747490 hvor "null" ble satt som svarId på spørsmålet om foreldre møtes. 

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25738)