### PR TITLE
Springdoc kun i preprod - vil fjerne warnings i logger

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,9 +26,9 @@ SAF_AUDIENCE: dev-fss:teamdokumenthandtering:safselvbetjening
 
 springdoc:
   api-docs:
-    enabled=true:
+    enabled: true
   packagesToScan: no.nav.familie.ef.søknad
   pathsToMatch: /v3/api-docs,/api/**
   swagger-ui:
-    enabled=true:
+    enabled: true
     disable-swagger-default-url: true

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,5 +25,10 @@ SAF_URL: https://safselvbetjening.dev-fss-pub.nais.io
 SAF_AUDIENCE: dev-fss:teamdokumenthandtering:safselvbetjening
 
 springdoc:
+  api-docs:
+    enabled=true:
+  packagesToScan: no.nav.familie.ef.søknad
+  pathsToMatch: /v3/api-docs,/api/**
   swagger-ui:
     enabled=true:
+    disable-swagger-default-url: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,8 +6,8 @@ server:
     context-path: /familie/alene-med-barn/soknad-api
 
 springdoc:
-  packagesToScan: no.nav.familie.ef.søknad
-  pathsToMatch: /v3/api-docs,/api/**
+  api-docs:
+    enabled=false:
   swagger-ui:
     disable-swagger-default-url: true
     enabled=false:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,10 +7,10 @@ server:
 
 springdoc:
   api-docs:
-    enabled=false:
+    enabled: false
   swagger-ui:
     disable-swagger-default-url: true
-    enabled=false:
+    enabled: false
 
 familie:
   ef:


### PR DESCRIPTION
Fortsatt warnings i logger etter https://github.com/navikt/familie-ef-soknad-api/pull/1220 

Vil fjerne warnings (og kun ha swagger i preprod) 