### PR TITLE
Overgangsstønad søknad regelendring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <mockk.version>1.14.9</mockk.version>
         <token-validation-spring.version>6.0.4</token-validation-spring.version>
         <felles.version>4.20260315040340_f2acdc7</felles.version>
-        <kontrakter.version>4.0_20260417102447_88161c0</kontrakter.version>
+        <kontrakter.version>4.0_20260427083013_f53660d</kontrakter.version>
         <start-class>no.nav.familie.ef.søknad.ApplicationKt</start-class>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <mockk.version>1.14.9</mockk.version>
         <token-validation-spring.version>6.0.4</token-validation-spring.version>
         <felles.version>4.20260315040340_f2acdc7</felles.version>
-        <kontrakter.version>4.0_20260326091316_bc0649b</kontrakter.version>
+        <kontrakter.version>4.0_20260417102447_88161c0</kontrakter.version>
         <start-class>no.nav.familie.ef.søknad.ApplicationKt</start-class>
     </properties>
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/config/MottakConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/config/MottakConfig.kt
@@ -12,6 +12,7 @@ data class MottakConfig(
     internal val sendInnSøknadBarnetilsynUri = byggUri(PATH_SEND_INN_SØKNAD_BARNETILSYN)
     internal val sendInnSøknadSkolepengerUri = byggUri(PATH_SEND_INN_SØKNAD_SKOLEPENGER)
     internal val sendInnSkjemaArbeidssøkerUri = byggUri(PATH_SEND_INN_SKJEMA_ARBEIDSSØKER)
+    internal val sendInnSøknadOvergangsstønadRegelendring2026Uri = byggUri(PATH_SEND_INN_SØKNAD_OVERGANGSSTØNAD_REGELENDRING_2026)
     internal val hentForrigeSøknadBarnetilsynUri = byggUri(PATH_HENT_FORRIGE_SØKNAD_BARNETILSYN)
     internal val hentSistInnsendteSøknadPerStønadUri = byggUri(PATH_HENT_SIST_INNSENDTE_SØKNAD_PER_STØNAD)
 
@@ -30,6 +31,7 @@ data class MottakConfig(
 
     companion object {
         private const val PATH_SEND_INN_SØKNAD_OVERGANGSSTØNAD = "/soknad/overgangsstonad"
+        private const val PATH_SEND_INN_SØKNAD_OVERGANGSSTØNAD_REGELENDRING_2026 = "/soknad/overgangsstonad-regelendring-2026"
         private const val PATH_SEND_INN_SØKNAD_BARNETILSYN = "/soknad/barnetilsyn"
         private const val PATH_SEND_INN_SØKNAD_SKOLEPENGER = "/soknad/skolepenger"
         private const val PATH_SEND_INN_SKJEMA_ARBEIDSSØKER = "/soknad/arbeidssoker"

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/MottakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/MottakClient.kt
@@ -9,6 +9,7 @@ import no.nav.familie.kontrakter.ef.søknad.SkjemaForArbeidssøker
 import no.nav.familie.kontrakter.ef.søknad.SøknadBarnetilsyn
 import no.nav.familie.kontrakter.ef.søknad.SøknadMedVedlegg
 import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønad
+import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønadRegelendring2026
 import no.nav.familie.kontrakter.ef.søknad.SøknadSkolepenger
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Tema
@@ -48,6 +49,8 @@ class MottakClient(
         )
 
     fun sendInnSøknadOvergangsstønad(søknadMedVedlegg: SøknadMedVedlegg<SøknadOvergangsstønad>): KvitteringDto = postForEntity(config.sendInnSøknadOverganggstønadUri, søknadMedVedlegg)
+
+    fun sendInnSøknadOvergangsstønadRegelendring2026(søknadMedVedlegg: SøknadMedVedlegg<SøknadOvergangsstønadRegelendring2026>): KvitteringDto = postForEntity(config.sendInnSøknadOvergangsstønadRegelendring2026Uri, søknadMedVedlegg)
 
     fun sendInnSøknadBarnetilsyn(søknadMedVedlegg: SøknadMedVedlegg<SøknadBarnetilsyn>): KvitteringDto = postForEntity(config.sendInnSøknadBarnetilsynUri, søknadMedVedlegg)
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadController.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ef.søknad.søknad.domain.Kvittering
 import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynDto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynGjenbrukDto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadOvergangsstønadDto
+import no.nav.familie.ef.søknad.søknad.dto.SøknadOvergangsstønadRegelendring2026Dto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadSkolepengerDto
 import no.nav.familie.sikkerhet.EksternBrukerUtils
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -38,6 +39,19 @@ class SøknadController(
 
         val innsendingMottatt = LocalDateTime.now()
         søknadService.sendInnSøknadOvergangsstønad(søknad, innsendingMottatt)
+        return Kvittering("ok", mottattDato = innsendingMottatt)
+    }
+
+    @PostMapping("overgangsstonad-regelendring-2026")
+    fun sendInn(
+        @RequestBody søknad: SøknadOvergangsstønadRegelendring2026Dto,
+    ): Kvittering {
+        if (!EksternBrukerUtils.personIdentErLikInnloggetBruker(søknad.person.søker.fnr)) {
+            throw ApiFeil("Fnr fra token matcher ikke fnr på søknaden", HttpStatus.FORBIDDEN)
+        }
+
+        val innsendingMottatt = LocalDateTime.now()
+        søknadService.sendInnSøknadOvergangsstønadRegelendring2026(søknad, innsendingMottatt)
         return Kvittering("ok", mottattDato = innsendingMottatt)
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadService.kt
@@ -7,11 +7,13 @@ import no.nav.familie.ef.søknad.søknad.domain.TekstFelt
 import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynDto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynGjenbrukDto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadOvergangsstønadDto
+import no.nav.familie.ef.søknad.søknad.dto.SøknadOvergangsstønadRegelendring2026Dto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadSkolepengerDto
 import no.nav.familie.ef.søknad.søknad.mapper.KvitteringMapper
 import no.nav.familie.ef.søknad.søknad.mapper.SkjemaMapper
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadBarnetilsynMapper
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadOvergangsstønadMapper
+import no.nav.familie.ef.søknad.søknad.mapper.SøknadOvergangsstønadRegelendring2026Mapper
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadSkolepengerMapper
 import no.nav.familie.kontrakter.felles.søknad.SistInnsendtSøknadDto
 import org.slf4j.LoggerFactory
@@ -22,6 +24,7 @@ import java.time.LocalDateTime
 class SøknadService(
     private val mottakClient: MottakClient,
     private val overgangsstønadMapper: SøknadOvergangsstønadMapper,
+    private val overgangsstønadRegelendring2026Mapper: SøknadOvergangsstønadRegelendring2026Mapper,
     private val barnetilsynMapper: SøknadBarnetilsynMapper,
     private val skolepengerMapper: SøknadSkolepengerMapper,
 ) {
@@ -34,6 +37,15 @@ class SøknadService(
     ): Kvittering {
         val søknadRequestData = overgangsstønadMapper.mapTilIntern(søknad, innsendingMottatt)
         val kvittering = mottakClient.sendInnSøknadOvergangsstønad(søknadRequestData)
+        return KvitteringMapper.mapTilEkstern(kvittering, innsendingMottatt)
+    }
+
+    fun sendInnSøknadOvergangsstønadRegelendring2026(
+        søknad: SøknadOvergangsstønadRegelendring2026Dto,
+        innsendingMottatt: LocalDateTime,
+    ): Kvittering {
+        val søknadRequestData = overgangsstønadRegelendring2026Mapper.mapTilIntern(søknad, innsendingMottatt)
+        val kvittering = mottakClient.sendInnSøknadOvergangsstønadRegelendring2026(søknadRequestData)
         return KvitteringMapper.mapTilEkstern(kvittering, innsendingMottatt)
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/dto/SøknadOvergangsstønadRegelendring2026Dto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/dto/SøknadOvergangsstønadRegelendring2026Dto.kt
@@ -22,7 +22,7 @@ data class SøknadOvergangsstønadRegelendring2026Dto(
     val medlemskap: Medlemskap,
     val bosituasjon: Bosituasjon,
     val hvaSituasjon: ListFelt<String>,
-    val harInntekt: ListFelt<String>,
+    val inntekter: ListFelt<String>,
     val firmaer: List<Firma>? = null,
     val sagtOppEllerRedusertStilling: TekstFelt? = null,
     val begrunnelseSagtOppEllerRedusertStilling: TekstFelt? = null,

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/dto/SøknadOvergangsstønadRegelendring2026Dto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/dto/SøknadOvergangsstønadRegelendring2026Dto.kt
@@ -27,7 +27,7 @@ data class SøknadOvergangsstønadRegelendring2026Dto(
     val sagtOppEllerRedusertStilling: TekstFelt? = null,
     val begrunnelseSagtOppEllerRedusertStilling: TekstFelt? = null,
     val datoSagtOppEllerRedusertStilling: DatoFelt? = null,
-    val søkerFraBestemtMåned: BooleanFelt? = null,
+    val søkerFraBestemtMåned: BooleanFelt,
     val søknadsdato: DatoFelt? = null,
     val dokumentasjonsbehov: List<Dokumentasjonsbehov>,
     val locale: String = "nb",

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/dto/SøknadOvergangsstønadRegelendring2026Dto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/dto/SøknadOvergangsstønadRegelendring2026Dto.kt
@@ -1,0 +1,35 @@
+package no.nav.familie.ef.søknad.søknad.dto
+
+import no.nav.familie.ef.søknad.søknad.domain.Adresseopplysninger
+import no.nav.familie.ef.søknad.søknad.domain.BooleanFelt
+import no.nav.familie.ef.søknad.søknad.domain.Bosituasjon
+import no.nav.familie.ef.søknad.søknad.domain.DatoFelt
+import no.nav.familie.ef.søknad.søknad.domain.Dokumentasjonsbehov
+import no.nav.familie.ef.søknad.søknad.domain.Firma
+import no.nav.familie.ef.søknad.søknad.domain.ListFelt
+import no.nav.familie.ef.søknad.søknad.domain.Medlemskap
+import no.nav.familie.ef.søknad.søknad.domain.Person
+import no.nav.familie.ef.søknad.søknad.domain.Sivilstatus
+import no.nav.familie.ef.søknad.søknad.domain.TekstFelt
+import java.time.LocalDate
+
+data class SøknadOvergangsstønadRegelendring2026Dto(
+    val erRegelendring2026: Boolean = true,
+    val person: Person,
+    val søkerBorPåRegistrertAdresse: BooleanFelt? = null,
+    val adresseopplysninger: Adresseopplysninger? = null,
+    val sivilstatus: Sivilstatus,
+    val medlemskap: Medlemskap,
+    val bosituasjon: Bosituasjon,
+    val hvaSituasjon: ListFelt<String>,
+    val harInntekt: ListFelt<String>,
+    val firmaer: List<Firma>? = null,
+    val sagtOppEllerRedusertStilling: TekstFelt? = null,
+    val begrunnelseSagtOppEllerRedusertStilling: TekstFelt? = null,
+    val datoSagtOppEllerRedusertStilling: DatoFelt? = null,
+    val søkerFraBestemtMåned: BooleanFelt? = null,
+    val søknadsdato: DatoFelt? = null,
+    val dokumentasjonsbehov: List<Dokumentasjonsbehov>,
+    val locale: String = "nb",
+    val datoPåbegyntSøknad: LocalDate? = null,
+)

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/AktivitetsMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/AktivitetsMapper.kt
@@ -132,7 +132,7 @@ object AktivitetsMapper : MapperMedVedlegg<AktivitetDto, Aktivitet>(ArbeidUtanni
             ),
         )
 
-    private fun mapOmFirmaer(firmaer: List<Firma>): List<Selvstendig> = firmaer.map { firma -> mapOmFirma(firma) }
+    internal fun mapOmFirmaer(firmaer: List<Firma>): List<Selvstendig> = firmaer.map { firma -> mapOmFirma(firma) }
 
     private fun mapOmFirma(firma: Firma): Selvstendig =
         Selvstendig(

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/StønadsstartMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/StønadsstartMapper.kt
@@ -17,6 +17,14 @@ object StønadsstartMapper {
         søkerFraBestemtMåned: BooleanFelt,
     ): Søknadsfelt<Stønadsstart> = Søknadsfelt(NårSøkerDuFra.hentTekst(), map(søknadsdato, søkerFraBestemtMåned))
 
+    fun mapStønadsstartNullable(
+        søknadsdato: DatoFelt?,
+        søkerFraBestemtMåned: BooleanFelt?,
+    ): Søknadsfelt<Stønadsstart> {
+        val ikkeSpesifisertMåned = BooleanFelt(label = "Søker du fra en bestemt måned?", verdi = false)
+        return mapStønadsstart(søknadsdato, søkerFraBestemtMåned ?: ikkeSpesifisertMåned)
+    }
+
     private fun map(
         søknadsdato: DatoFelt?,
         søkerFraBestemtMåned: BooleanFelt,

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/StønadsstartMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/StønadsstartMapper.kt
@@ -17,14 +17,6 @@ object StønadsstartMapper {
         søkerFraBestemtMåned: BooleanFelt,
     ): Søknadsfelt<Stønadsstart> = Søknadsfelt(NårSøkerDuFra.hentTekst(), map(søknadsdato, søkerFraBestemtMåned))
 
-    fun mapStønadsstartNullable(
-        søknadsdato: DatoFelt?,
-        søkerFraBestemtMåned: BooleanFelt?,
-    ): Søknadsfelt<Stønadsstart> {
-        val ikkeSpesifisertMåned = BooleanFelt(label = "Søker du fra en bestemt måned?", verdi = false)
-        return mapStønadsstart(søknadsdato, søkerFraBestemtMåned ?: ikkeSpesifisertMåned)
-    }
-
     private fun map(
         søknadsdato: DatoFelt?,
         søkerFraBestemtMåned: BooleanFelt,

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/SøknadOvergangsstønadRegelendring2026Mapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/SøknadOvergangsstønadRegelendring2026Mapper.kt
@@ -45,7 +45,7 @@ class SøknadOvergangsstønadRegelendring2026Mapper {
                 sivilstandsplaner = SivilstandsplanerMapper.map(dto.bosituasjon),
                 barn = dto.person.barn.tilSøknadsfelt(vedlegg),
                 hvaSituasjon = dto.hvaSituasjon.tilSøknadsfelt(),
-                harInntekt = dto.harInntekt.tilSøknadsfelt(),
+                inntekter = dto.inntekter.tilSøknadsfelt(),
                 firmaer = dto.firmaer?.let { Søknadsfelt(OmFirmaDuDriver.hentTekst(), mapOmFirmaer(it)) },
                 sagtOppEllerRedusertStilling = dto.sagtOppEllerRedusertStilling?.tilSøknadsfelt(),
                 begrunnelseSagtOppEllerRedusertStilling = dto.begrunnelseSagtOppEllerRedusertStilling?.tilSøknadsfelt(),

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/SøknadOvergangsstønadRegelendring2026Mapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/SøknadOvergangsstønadRegelendring2026Mapper.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ef.søknad.søknad.mapper
 
 import no.nav.familie.ef.søknad.søknad.dto.SøknadOvergangsstønadRegelendring2026Dto
 import no.nav.familie.ef.søknad.søknad.mapper.AktivitetsMapper.mapOmFirmaer
-import no.nav.familie.ef.søknad.søknad.mapper.StønadsstartMapper.mapStønadsstartNullable
+import no.nav.familie.ef.søknad.søknad.mapper.StønadsstartMapper.mapStønadsstart
 import no.nav.familie.ef.søknad.utils.DokumentasjonWrapper
 import no.nav.familie.ef.søknad.utils.Språk
 import no.nav.familie.ef.søknad.utils.Språktekster.OmFirmaDuDriver
@@ -50,7 +50,7 @@ class SøknadOvergangsstønadRegelendring2026Mapper {
                 sagtOppEllerRedusertStilling = dto.sagtOppEllerRedusertStilling?.tilSøknadsfelt(),
                 begrunnelseSagtOppEllerRedusertStilling = dto.begrunnelseSagtOppEllerRedusertStilling?.tilSøknadsfelt(),
                 datoSagtOppEllerRedusertStilling = dto.datoSagtOppEllerRedusertStilling?.tilSøknadsfelt(),
-                stønadsstart = mapStønadsstartNullable(dto.søknadsdato, dto.søkerFraBestemtMåned),
+                stønadsstart = mapStønadsstart(dto.søknadsdato, dto.søkerFraBestemtMåned),
             )
 
         return SøknadMedVedlegg<SøknadOvergangsstønadRegelendring2026>(

--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/SøknadOvergangsstønadRegelendring2026Mapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/mapper/SøknadOvergangsstønadRegelendring2026Mapper.kt
@@ -1,0 +1,62 @@
+package no.nav.familie.ef.søknad.søknad.mapper
+
+import no.nav.familie.ef.søknad.søknad.dto.SøknadOvergangsstønadRegelendring2026Dto
+import no.nav.familie.ef.søknad.søknad.mapper.AktivitetsMapper.mapOmFirmaer
+import no.nav.familie.ef.søknad.søknad.mapper.StønadsstartMapper.mapStønadsstartNullable
+import no.nav.familie.ef.søknad.utils.DokumentasjonWrapper
+import no.nav.familie.ef.søknad.utils.Språk
+import no.nav.familie.ef.søknad.utils.Språktekster.OmFirmaDuDriver
+import no.nav.familie.ef.søknad.utils.hentTekst
+import no.nav.familie.ef.søknad.utils.kontekst
+import no.nav.familie.ef.søknad.utils.lagDokumentasjonWrapper
+import no.nav.familie.ef.søknad.utils.tilKontrakt
+import no.nav.familie.ef.søknad.utils.tilSøknadsfelt
+import no.nav.familie.kontrakter.ef.søknad.SøknadMedVedlegg
+import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønadRegelendring2026
+import no.nav.familie.kontrakter.ef.søknad.Søknadsfelt
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class SøknadOvergangsstønadRegelendring2026Mapper {
+    fun mapTilIntern(
+        dto: SøknadOvergangsstønadRegelendring2026Dto,
+        innsendingMottatt: LocalDateTime,
+    ): SøknadMedVedlegg<SøknadOvergangsstønadRegelendring2026> {
+        kontekst.set(Språk.fromString(dto.locale))
+        val vedlegg: Map<String, DokumentasjonWrapper> = lagDokumentasjonWrapper(dto.dokumentasjonsbehov)
+
+        val søknad =
+            SøknadOvergangsstønadRegelendring2026(
+                erRegelendring2026 = dto.erRegelendring2026,
+                innsendingsdetaljer = FellesMapper.mapInnsendingsdetaljer(innsendingMottatt, dto.datoPåbegyntSøknad, dto.locale),
+                personalia = PersonaliaMapper.map(dto.person.søker),
+                adresseopplysninger =
+                    AdresseopplysningerMapper.map(
+                        AdresseopplysningerData(
+                            dto.søkerBorPåRegistrertAdresse,
+                            dto.adresseopplysninger,
+                        ),
+                        vedlegg,
+                    ),
+                sivilstandsdetaljer = SivilstandsdetaljerMapper.map(dto.sivilstatus, vedlegg),
+                medlemskapsdetaljer = MedlemsskapsMapper.map(dto.medlemskap),
+                bosituasjon = BosituasjonMapper.map(dto.bosituasjon, vedlegg),
+                sivilstandsplaner = SivilstandsplanerMapper.map(dto.bosituasjon),
+                barn = dto.person.barn.tilSøknadsfelt(vedlegg),
+                hvaSituasjon = dto.hvaSituasjon.tilSøknadsfelt(),
+                harInntekt = dto.harInntekt.tilSøknadsfelt(),
+                firmaer = dto.firmaer?.let { Søknadsfelt(OmFirmaDuDriver.hentTekst(), mapOmFirmaer(it)) },
+                sagtOppEllerRedusertStilling = dto.sagtOppEllerRedusertStilling?.tilSøknadsfelt(),
+                begrunnelseSagtOppEllerRedusertStilling = dto.begrunnelseSagtOppEllerRedusertStilling?.tilSøknadsfelt(),
+                datoSagtOppEllerRedusertStilling = dto.datoSagtOppEllerRedusertStilling?.tilSøknadsfelt(),
+                stønadsstart = mapStønadsstartNullable(dto.søknadsdato, dto.søkerFraBestemtMåned),
+            )
+
+        return SøknadMedVedlegg<SøknadOvergangsstønadRegelendring2026>(
+            søknad = søknad,
+            vedlegg = vedlegg.values.flatMap { it.vedlegg },
+            dokumentasjonsbehov = dto.dokumentasjonsbehov.tilKontrakt(),
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/søknad/søknad/SøknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/søknad/SøknadServiceTest.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ef.søknad.søknad.domain.PersonTilGjenbruk
 import no.nav.familie.ef.søknad.søknad.domain.SvarId
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadBarnetilsynMapper
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadOvergangsstønadMapper
+import no.nav.familie.ef.søknad.søknad.mapper.SøknadOvergangsstønadRegelendring2026Mapper
 import no.nav.familie.ef.søknad.søknad.mapper.SøknadSkolepengerMapper
 import no.nav.familie.kontrakter.ef.søknad.SøknadBarnetilsyn
 import no.nav.familie.kontrakter.felles.jsonMapper
@@ -20,6 +21,7 @@ class SøknadServiceTest {
         SøknadService(
             mottakClient = mottakClient,
             overgangsstønadMapper = SøknadOvergangsstønadMapper(),
+            overgangsstønadRegelendring2026Mapper = SøknadOvergangsstønadRegelendring2026Mapper(),
             barnetilsynMapper = SøknadBarnetilsynMapper(),
             skolepengerMapper = SøknadSkolepengerMapper(),
         )


### PR DESCRIPTION
Tar inn ny flatere overgangsstønad søknad struktur, mapper det om lagrer det i mottak. Dette er en del av flere PRer for andre apper.

- Bruker ny versjon av kontrakt som har strukturen SøknadOvergangsstønadRegelendring2026, denne brukes på tvers av apper.
- Nytt endtepunkt for å ta i mot overgangsstønad søknad med regelendring
- Mapper for ny søknad

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28466)