### PR TITLE
OS regelverksendring tidligere vedtakshistorikk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/config/SaksbehandlingConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/infrastruktur/config/SaksbehandlingConfig.kt
@@ -9,6 +9,7 @@ data class SaksbehandlingConfig(
     val uri: URI,
 ) {
     internal val hentStønadsperioderUri = byggUri(PATH_HENT_STØNADSPERIODER)
+    internal val harTidligereInnvilgetVedtakUri = byggUri(PATH_HAR_TIDLIGERE_INNVILGET_VEDTAK)
     internal val pingUri = byggUri(PATH_PING)
 
     private fun byggUri(path: String) =
@@ -20,6 +21,7 @@ data class SaksbehandlingConfig(
 
     companion object {
         private const val PATH_HENT_STØNADSPERIODER = "/ekstern/minside/stonadsperioder"
+        private const val PATH_HAR_TIDLIGERE_INNVILGET_VEDTAK = "/ekstern/soknad/har-tidligere-innvilget-vedtak"
         private const val PATH_PING = "ping"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/søknad/minside/SaksbehandlingClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/minside/SaksbehandlingClient.kt
@@ -22,4 +22,9 @@ class SaksbehandlingClient(
         getForEntity<Ressurs<StønadsperioderDto>>(
             UriComponentsBuilder.fromUriString("${config.hentStønadsperioderUri}").build().toUri(),
         ).getDataOrThrow()
+
+    fun harTidligereInnvilgetVedtak(): String =
+        getForEntity<Ressurs<String>>(
+            UriComponentsBuilder.fromUriString("${config.harTidligereInnvilgetVedtakUri}").build().toUri(),
+        ).getDataOrThrow()
 }

--- a/src/main/kotlin/no/nav/familie/ef/søknad/minside/SaksbehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/minside/SaksbehandlingController.kt
@@ -14,4 +14,7 @@ class SaksbehandlingController(
 ) {
     @GetMapping("/stonadsperioder")
     fun hentStønadsperioderForBruker() = saksbehandlingService.hentStønadsperioderForBruker()
+
+    @GetMapping("/har-tidligere-innvilget-vedtak")
+    fun harTidligereInnvilgetVedtak() = saksbehandlingService.harTidligereInnvilgetVedtak()
 }

--- a/src/main/kotlin/no/nav/familie/ef/søknad/minside/SaksbehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/minside/SaksbehandlingService.kt
@@ -30,6 +30,8 @@ class SaksbehandlingService(
         return mineStønaderDto
     }
 
+    fun harTidligereInnvilgetVedtak(): String = saksbehandlingClient.harTidligereInnvilgetVedtak()
+
     private fun utledStønad(stønader: List<StønadsperiodeDto>): Stønad {
         val perioderSortertPåDato = stønader.sortedBy { it.fraDato }
 


### PR DESCRIPTION
Gjør kall mot ef-sak på vegne av søknad for å sjekke om personen som søker har tidligere vedtak som enslig forsørger. Verdien brukes til å avgjøre hvilken versjon av søknaden som skal brukes i frontend.

[favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28467)