### PR TITLE
Sett lik memory request og limit

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -27,7 +27,7 @@ spec:
     limits:
       memory: 2Gi
     requests:
-      memory: 256Mi
+      memory: 2Gi
       cpu: 100m
   ingresses:
     - https://familie-ef-soknad-api.intern.dev.nav.no

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -27,7 +27,7 @@ spec:
     limits:
       memory: 2Gi
     requests:
-      memory: 1024Mi
+      memory: 2Gi
       cpu: 100m
   ingresses:
     - https://www.nav.no/familie/alene-med-barn/soknad-api


### PR DESCRIPTION
## Hva
Setter `resources.requests.memory` lik `resources.limits.memory` i nais.yaml-filene.

## Hvorfor
Anbefalt praksis for Kubernetes-ressurser er å ha requests og limits like for minne, se
https://www.flexera.com/blog/finops/kubernetes-limits-vs-requests-key-differences-and-how-they-work/#s5

Ingen CPU-limit er satt i denne appen, så det er ikke gjort endringer der.
