### PR TITLE
Juster ressurser etter Nais-anbefaling

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -25,10 +25,10 @@ spec:
     max: 2
   resources:
     limits:
-      memory: 2Gi
+      memory: 1Gi
     requests:
-      memory: 2Gi
-      cpu: 100m
+      memory: 1Gi
+      cpu: 75m
   ingresses:
     - https://familie-ef-soknad-api.intern.dev.nav.no
   azure:

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -25,10 +25,10 @@ spec:
     max: 4
   resources:
     limits:
-      memory: 2Gi
+      memory: 1152Mi
     requests:
-      memory: 2Gi
-      cpu: 100m
+      memory: 1152Mi
+      cpu: 400m
   ingresses:
     - https://www.nav.no/familie/alene-med-barn/soknad-api
   azure:


### PR DESCRIPTION
## Hva
Justerer CPU/memory requests og limits etter Nais console sine anbefalinger (basert på faktisk bruk). Forrige runde satte vi `memory request = limit`, men på de gamle høye verdiene, noe som ga over-reservering flagget som «dyrere ressurser enn forventet».

## Hvordan
- **Memory:** `request = limit` beholdt (Guaranteed QoS), satt til Nais sitt anbefalte limit avrundet til ren verdi.
- **CPU request** justert mot anbefaling. Ingen CPU-limit.