### PR TITLE
Deaktiverer gjenbruk av søknad

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/søknad/søknad/SøknadController.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ef.søknad.person.OppslagService
 import no.nav.familie.ef.søknad.søknad.domain.Arbeidssøker
 import no.nav.familie.ef.søknad.søknad.domain.Kvittering
 import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynDto
-import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynGjenbrukDto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadOvergangsstønadDto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadOvergangsstønadRegelendring2026Dto
 import no.nav.familie.ef.søknad.søknad.dto.SøknadSkolepengerDto
@@ -88,17 +87,6 @@ class SøknadController(
         val innsendingMottatt = LocalDateTime.now()
         søknadService.sendInnArbeidssøkerSkjema(arbeidssøker, fnrFraToken, forkortetNavn, innsendingMottatt)
         return Kvittering("ok", mottattDato = innsendingMottatt)
-    }
-
-    @GetMapping("barnetilsyn/forrige")
-    fun hentForrigeBarnetilsynSøknad(): SøknadBarnetilsynGjenbrukDto? {
-        val søknad = søknadService.hentForrigeBarnetilsynSøknadKvittering()
-
-        return if (søknad != null && søknadService.harSøknadGyldigeVerdier(søknad)) {
-            søknad
-        } else {
-            null
-        }
     }
 
     @GetMapping("sist-innsendt-per-stonad")

--- a/src/test/kotlin/no/nav/familie/ef/søknad/søknad/SøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/søknad/søknad/SøknadControllerTest.kt
@@ -10,8 +10,6 @@ import no.nav.familie.ef.søknad.mock.søknadOvergangsstønadDto
 import no.nav.familie.ef.søknad.mock.søknadSkolepengerDto
 import no.nav.familie.ef.søknad.søknad.domain.Kvittering
 import no.nav.familie.ef.søknad.søknad.domain.Person
-import no.nav.familie.ef.søknad.søknad.dto.SøknadBarnetilsynGjenbrukDto
-import no.nav.familie.ef.søknad.søknad.mapper.SøknadBarnetilsynMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -23,7 +21,6 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpEntity
-import org.springframework.http.HttpMethod.GET
 import org.springframework.http.HttpMethod.POST
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
@@ -129,34 +126,6 @@ class SøknadControllerTest {
 
             assertThat(response.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
             verify(exactly = 0) { søknadService.sendInnSøknadBarnetilsyn(søknad, any()) }
-        }
-
-        @Test
-        fun `skal returnere 200 dersom forrige barnetilsyn søknad ikke finnes`() {
-            val søknad = søknadBarnetilsynDto().copy(person = Person(søker = søkerMedDefaultVerdier(forventetFnr = tokenSubject), barn = listOf()))
-
-            every { søknadService.hentForrigeBarnetilsynSøknadKvittering() } returns null
-            every { søknadService.harSøknadGyldigeVerdier(any()) } returns false
-            val response =
-                restTemplate.exchange<String>(localhost("/api/soknad/barnetilsyn/forrige"), GET, HttpEntity(søknad, headers))
-
-            assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-            assertThat(response.body).isNull()
-        }
-
-        @Test
-        fun `skal returnere forrige barnetilsyn søknad når den finnes`() {
-            val søknad = søknadBarnetilsynDto().copy(person = Person(søker = søkerMedDefaultVerdier(forventetFnr = tokenSubject), barn = listOf()))
-            val søknadMedVedlegg = SøknadBarnetilsynMapper().mapTilIntern(søknad, LocalDateTime.now(), true)
-            every { søknadService.hentForrigeBarnetilsynSøknadKvittering() } returns SøknadBarnetilsynMapper().mapTilDto(søknadMedVedlegg.søknad)
-            every { søknadService.harSøknadGyldigeVerdier(any()) } returns true
-            val response =
-                restTemplate.exchange<SøknadBarnetilsynGjenbrukDto>(
-                    localhost("/api/soknad/barnetilsyn/forrige"),
-                    GET,
-                    HttpEntity<String>(headers),
-                )
-            assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         }
 
         @Test


### PR DESCRIPTION
Det hender det feiler på noe mapping i prod, men det er nedprioritert å fikse. Fjerner bare endepunkt, i tilfelle man ønsker å ta det i bruk igjen.

https://github.com/navikt/familie-ef-soknad-frontend/pull/2276